### PR TITLE
CI: make Coveralls steps non-fatal

### DIFF
--- a/.github/workflows/embedding-ci.yml
+++ b/.github/workflows/embedding-ci.yml
@@ -55,6 +55,7 @@ jobs:
         pytest tests/ --cov=copilot_embedding --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,6 +156,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ingestion-ci.yml
+++ b/.github/workflows/ingestion-ci.yml
@@ -57,6 +57,7 @@ jobs:
         pytest tests/ --cov=app --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -245,6 +246,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-auth-adapter.yml
+++ b/.github/workflows/test-auth-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/ -v --tb=short --junit-xml=test-results.xml --cov=copilot_auth --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +115,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-config-adapter.yml
+++ b/.github/workflows/test-config-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/ -v --tb=short --junit-xml=test-results.xml --cov=copilot_config --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +115,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-events-adapter.yml
+++ b/.github/workflows/test-events-adapter.yml
@@ -49,6 +49,7 @@ jobs:
         pytest tests/ -v --tb=short -m "not integration" --junit-xml=test-results.xml --cov=copilot_events --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -113,6 +114,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-logging-adapter.yml
+++ b/.github/workflows/test-logging-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/ -v --tb=short --junit-xml=test-results.xml --cov=copilot_logging --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +115,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-metrics-adapter.yml
+++ b/.github/workflows/test-metrics-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/ -v --tb=short --junit-xml=test-results.xml --cov=copilot_metrics --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +115,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-reporting-adapter.yml
+++ b/.github/workflows/test-reporting-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/ -v --tb=short --junit-xml=test-results.xml --cov=copilot_reporting --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -114,6 +115,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-storage-adapter.yml
+++ b/.github/workflows/test-storage-adapter.yml
@@ -50,6 +50,7 @@ jobs:
         pytest tests/test_document_store.py -v --tb=short --junit-xml=test-results.xml --cov=copilot_storage --cov-report=lcov --cov-report=html --cov-report=term
 
     - name: Upload coverage to Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -328,6 +329,7 @@ jobs:
     if: always()
     steps:
     - name: Finalize Coveralls
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary
- Make Coveralls upload and finalize steps non-fatal across all CI workflows by adding `continue-on-error: true`.

Changes
- Updated workflows: `.github/workflows/test-auth-adapter.yml`, `.github/workflows/test-config-adapter.yml`, `.github/workflows/test-events-adapter.yml`, `.github/workflows/test-logging-adapter.yml`, `.github/workflows/test-metrics-adapter.yml`, `.github/workflows/test-reporting-adapter.yml`, `.github/workflows/test-storage-adapter.yml`, `.github/workflows/ingestion-ci.yml`, `.github/workflows/embedding-ci.yml`.

Motivation
- Coveralls.io connectivity issues should not fail CI; tests and lint should gate success instead.

Notes
- No functional code changes; workflow-only adjustments.
- CI should remain green even if Coveralls cannot be reached.
