### PR TITLE
Add document on using Copilot for civic infrastructure

### DIFF
--- a/documents/BUILDING_WITH_COPILOT.md
+++ b/documents/BUILDING_WITH_COPILOT.md
@@ -4,7 +4,7 @@
 
 ## 🧭 Overview
 
-This document captures how GitHub Copilot was used to scaffold a modular, schema-governed microservice architecture for civic tooling. It outlines a repeatable pattern for using Copilot effectively in principled, contributor-friendly projects like [Copilot for Consensus](https://github.com/Alan-Jowett/CoPilot-For-Consensus).
+This document captures how GitHub Copilot was used to scaffold a modular, schema-governed microservice architecture for civic tooling. It outlines a repeatable pattern for using Copilot effectively in principled, contributor-friendly projects like [Copilot for Consensus](https://github.com/Alan-Jowett/Copilot-for-Consensus).
 
 ---
 


### PR DESCRIPTION
This document outlines the use of GitHub Copilot in building a modular microservice architecture for civic tooling, detailing collaboration patterns, outcomes, and takeaways for effective use.