### PR TITLE
Add scheduled daily runs and manual trigger support to CI workflows

### DIFF
--- a/.github/workflows/adapters-ci.yml
+++ b/.github/workflows/adapters-ci.yml
@@ -34,6 +34,7 @@ concurrency:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     outputs:
       copilot_auth: ${{ steps.filter.outputs.copilot_auth }}
       copilot_chunking: ${{ steps.filter.outputs.copilot_chunking }}
@@ -98,7 +99,7 @@ jobs:
 
   auth-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_auth == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_auth == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_auth
@@ -107,7 +108,7 @@ jobs:
 
   config-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_config == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_config == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_config
@@ -116,7 +117,7 @@ jobs:
 
   events-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_events == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_events == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_events
@@ -125,7 +126,7 @@ jobs:
 
   logging-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_logging == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_logging == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_logging
@@ -134,7 +135,7 @@ jobs:
 
   metrics-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_metrics == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_metrics == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_metrics
@@ -143,7 +144,7 @@ jobs:
 
   archive-fetcher-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_archive_fetcher == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_archive_fetcher == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_archive_fetcher
@@ -152,7 +153,7 @@ jobs:
 
   archive-fetcher-integration-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_archive_fetcher == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_archive_fetcher == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-integration-ci.yml
     with:
       adapter_id: copilot_archive_fetcher
@@ -164,7 +165,7 @@ jobs:
 
   reporting-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_reporting == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_reporting == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_reporting
@@ -173,7 +174,7 @@ jobs:
 
   storage-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_storage == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_storage == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_storage
@@ -182,7 +183,7 @@ jobs:
 
   embedding-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_embedding == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_embedding == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_embedding
@@ -191,7 +192,7 @@ jobs:
 
   chunking-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_chunking == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_chunking == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_chunking
@@ -200,7 +201,7 @@ jobs:
 
   consensus-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_consensus == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_consensus == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_consensus
@@ -209,7 +210,7 @@ jobs:
 
   schema-validation-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_schema_validation == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_schema_validation == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_schema_validation
@@ -218,7 +219,7 @@ jobs:
 
   summarization-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_summarization == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_summarization == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_summarization
@@ -227,7 +228,7 @@ jobs:
 
   vectorstore-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_vectorstore == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_vectorstore == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_vectorstore
@@ -237,7 +238,7 @@ jobs:
 
   storage-integration-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_storage == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_storage == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-integration-ci.yml
     with:
       adapter_id: copilot_storage
@@ -246,7 +247,7 @@ jobs:
 
   events-integration-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_events == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_events == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-integration-ci.yml
     with:
       adapter_id: copilot_events
@@ -255,7 +256,7 @@ jobs:
 
   schema-validation-integration-ci:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_schema_validation == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_schema_validation == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-integration-ci.yml
     with:
       adapter_id: copilot_schema_validation
@@ -264,7 +265,7 @@ jobs:
 
   draft-diff:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_draft_diff == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.copilot_draft_diff == 'true' || needs.detect-changes.outputs.ci_workflows == 'true' }}
     uses: ./.github/workflows/adapter-reusable-unit-test-ci.yml
     with:
       adapter_id: copilot_draft_diff

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -48,6 +48,7 @@ concurrency:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
     outputs:
       chunking: ${{ steps.filter.outputs.chunking }}
       embedding: ${{ steps.filter.outputs.embedding }}
@@ -98,7 +99,7 @@ jobs:
 
   chunking:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.chunking == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.chunking == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'chunking'
@@ -109,7 +110,7 @@ jobs:
 
   embedding:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.embedding == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.embedding == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'embedding'
@@ -120,7 +121,7 @@ jobs:
 
   ingestion:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.ingestion == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.ingestion == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'ingestion'
@@ -131,7 +132,7 @@ jobs:
 
   orchestrator:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.orchestrator == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.orchestrator == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'orchestrator'
@@ -142,7 +143,7 @@ jobs:
 
   parsing:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.parsing == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.parsing == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'parsing'
@@ -153,7 +154,7 @@ jobs:
 
   reporting:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.reporting == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.reporting == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'reporting'
@@ -164,7 +165,7 @@ jobs:
 
   summarization:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.summarization == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.summarization == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'summarization'
@@ -175,7 +176,7 @@ jobs:
 
   error-reporting:
     needs: detect-changes
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.error-reporting == 'true' || needs.detect-changes.outputs.ci-workflows == 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.error-reporting == 'true' || needs.detect-changes.outputs.ci-workflows == 'true') }}
     uses: ./.github/workflows/service-reusable-unit-test-ci.yml
     with:
       service_id: 'error-reporting'


### PR DESCRIPTION
## Summary
This PR enhances the CI workflows by adding scheduled runs and manual triggering capabilities.

## Changes
- **Daily Scheduled Runs**: Added cron schedule (2 AM UTC) to run all tests daily regardless of code changes
- **Manual Triggers**: Added \workflow_dispatch\ to allow on-demand workflow execution from GitHub Actions UI
- **Updated Job Conditions**: Modified all job conditions to run when triggered manually or on schedule

## Benefits
- Comprehensive daily testing to catch integration issues early
- Ability to manually trigger full test suites on-demand
- Maintains existing behavior for push/PR events (only changed components)