### PR TITLE
Rename Adapters CI workflow

### DIFF
--- a/.github/workflows/adapters-ci.yml
+++ b/.github/workflows/adapters-ci.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-name: Adapters CI (Changed-Only)
+name: Adapters CI
 
 on:
   push:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by renaming the workflow from "Adapters CI (Changed-Only)" to "Adapters CI" in the `.github/workflows/adapters-ci.yml` file.