### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,13 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
 
+  # Monitor Python dependencies in scripts service
+  - package-ecosystem: "pip"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
   # Monitor Python dependencies in summarization service
   - package-ecosystem: "pip"
     directory: "/summarization"


### PR DESCRIPTION
This pull request adds Dependabot configuration to monitor Python dependencies in the `scripts` service, ensuring that dependencies in that directory are kept up to date automatically.

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R61-R67): Added a new `pip` package-ecosystem entry for the `/scripts` directory to enable weekly monitoring and updates of Python dependencies in the `scripts` service.