### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/service-reusable-unit-test-ci.yml
+++ b/.github/workflows/service-reusable-unit-test-ci.yml
@@ -2,6 +2,8 @@
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
 name: Reusable Service Unit Test CI
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/3](https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/3)

To fix this issue, the workflow must explicitly set a `permissions` block, ideally at the top level (workflow root), which will apply the minimal required permissions to all jobs by default. From the lines provided, none of the jobs appear to require write access to repository contents, so `contents: read` is safest as a starting baseline. Any exceptions requiring additional permissions (e.g., publishing coverage or posting comments) can override or add permissions at the individual job or step if truly needed, but based on the actions used (`coverallsapp/github-action`, `upload-artifact`, etc.), `contents: read` is generally sufficient.

To implement the fix:
- Add a `permissions:` block after the `name:` line and before `on:` (so at line 5, shifting subsequent lines down).
- Set its value to `contents: read`.
- No further imports or definitions are needed; it's a YAML change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
