### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/service-reusable-unit-test-ci.yml
+++ b/.github/workflows/service-reusable-unit-test-ci.yml
@@ -144,6 +144,8 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/5](https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/5)

The best solution is to add an explicit `permissions` block granting only the minimal required privileges to each job that does not already specify one, or at the workflow root to apply a secure default for all jobs. Based on the code shown (specifically for the `build-docker` job highlighted by CodeQL as missing permissions), it does not appear to require any write-level permissions—it only checks out code and builds a Docker image, so `contents: read` is sufficient. To ensure minimal permissions, add `permissions: { contents: read }` to the `build-docker` job. You could also place the block at the workflow root for all jobs if none need more, but since the alert specifically highlights the `build-docker` job, we'll address it on that job for precision.  
No new methods, imports, or definitions are needed for this YAML change; only insert the `permissions:` line at the appropriate location in job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
