### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/service-reusable-unit-test-ci.yml
+++ b/.github/workflows/service-reusable-unit-test-ci.yml
@@ -3,6 +3,9 @@
 
 name: Reusable Service Unit Test CI
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/6](https://github.com/Alan-Jowett/CoPilot-For-Consensus/security/code-scanning/6)

The best, simplest, and most reliable fix is to add a root-level `permissions` block to the workflow file. This ensures that all jobs default to these minimal permissions unless they need more and specify it. In this workflow, all jobs only require read access to repository contents (for checkout, reading code, and running local builds/lint/tests), so setting `permissions: contents: read` at the top-level is the correct, least-privilege choice. The change should insert the following block after the `name` (line 4) and before the `on` (line 6) lines:

```yaml
permissions:
  contents: read
```

No other code, settings, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
