### PR TITLE
docs: add Copilot intent for ingesting live IETF mailing list data

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -550,6 +550,40 @@ Write-Host "✅ Docker Compose Workflow completed successfully" -ForegroundColor
 Example usage:
 - `"run the docker compose workflow"` → executes full end-to-end workflow locally, stops on first error
 
+#### "review PR <number>"
+
+Meaning: Review an open pull request without changing code. Summarize what the PR does, list any issues found, and highlight actionable suggestions. Do not push commits.
+
+Process:
+- Fetch PR details and diffs using GitHub MCP.
+- Read review comments and CI status.
+- Provide a concise review summary: scope, risk, correctness, style, docs/tests.
+- Add non-blocking/blocking comments as needed via PR review comment, but avoid code changes.
+
+Example usage:
+- "review PR 310" → returns a summary of changes, potential issues, and suggestions, but makes no commits.
+
+#### "review and respond to PR <number>"
+
+Meaning: Actively address review feedback on the specified PR. Apply straightforward documentation or configuration updates, push changes to the PR branch, and reply inline to review comments explaining the fixes. Ask for clarification if a comment is ambiguous.
+
+Process:
+1) Retrieve PR review comments and files using GitHub MCP.
+2) For each actionable comment:
+  - Update the relevant files (docs/config/scripts), keeping changes minimal and scoped.
+  - Commit with a descriptive message referencing the change.
+  - Push to the PR branch.
+  - Reply to the specific review thread describing what changed.
+3) If a comment is unclear or requires design input, reply asking for clarification rather than guessing.
+
+Notes:
+- Prefer not to modify application logic unless explicitly requested.
+- Keep edits surgical and reference exact lines/sections fixed.
+- Do not mark threads resolved unless requested by a maintainer.
+
+Example usage:
+- "review and respond to PR 310" → fetches comments, applies agreed doc fixes, pushes, and posts replies.
+
 #### "file an issue for this"
 
 Meaning: Create a GitHub issue for a problem or task discussed in the current conversation. Examine the recent conversation context to determine what the user is referring to. If the issue is ambiguous or unclear, ask the user for clarification before filing.


### PR DESCRIPTION
## Description

Adds a new natural language intent `"ingest live data from ietf-<topic>"` to the Copilot instructions. This allows users to programmatically ingest real IETF mailing list archives by specifying the topic.

### Usage

- **Command**: `"ingest live data from ietf-ipsec"`
- **Result**: Creates source named `ietf-ipsec`, fetches from `rsync.ietf.org::mailman-archive/ipsec/`, uploads to DocumentDB, and runs the ingestion batch job.

### Examples

- `"ingest live data from ietf-ipsec"` → ingests from `rsync.ietf.org::mailman-archive/ipsec/`
- `"ingest live data from ietf-quic"` → ingests from `rsync.ietf.org::mailman-archive/quic/`
- `"ingest live data from ietf-http"` → ingests from `rsync.ietf.org::mailman-archive/http/`

### Implementation

- Creates a temporary ingestion source configuration
- Uploads it to DocumentDB via the ingestion utility
- Runs the ingestion batch job
- Cleans up the temporary config

### Platform Support

- **Linux/macOS** (bash)
- **Windows** (PowerShell)

### Related

Complements the existing `"ingest test data"` intent which uses a local fixture. This intent enables direct ingestion of real IETF archives.