### PR TITLE
Fix Windows Docker mount syntax and parsing service error reporting

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -210,8 +210,8 @@ $configContent = @{
 Set-Content -Path $configFile -Value $configContent -Encoding UTF8
 
 # 2) Upload the ingestion source to DocumentDB (mount the config file into the container)
-docker compose run --rm -v $configFile:$configFile:ro ingestion `
-  python /app/upload_ingestion_sources.py $configFile
+docker compose run --rm -v "$configFile`:/app/config.json:ro" ingestion `
+  python /app/upload_ingestion_sources.py /app/config.json
 
 # 3) Run the ingestion batch job (runs once and exits)
 docker compose run --rm ingestion

--- a/parsing/app/service.py
+++ b/parsing/app/service.py
@@ -257,7 +257,7 @@ class ParsingService:
                     extra={"original_error": str(e), "publish_error": str(publish_error)}
                 )
                 if self.error_reporter:
-                    self.error_reporter.capture_exception()
+                    self.error_reporter.report(publish_error, context={"archive_id": archive_id})
                 # Re-raise the original exception to trigger message requeue
                 raise e from publish_error
             
@@ -511,10 +511,10 @@ class ParsingService:
                 routing_key="parsing.failed",
                 event=event.to_dict(),
             )
-        except Exception:
+        except Exception as e:
             logger.exception(f"Exception while publishing ParsingFailed event for {archive_id}")
             if self.error_reporter:
-                self.error_reporter.capture_exception()
+                self.error_reporter.report(e, context={"archive_id": archive_id})
             raise
 
     def get_stats(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Fixes two issues discovered during IETF mailing list ingestion testing:

### Issue #329: Windows PowerShell Docker Mount Syntax
**Problem**: The "ingest live data from ietf-<topic>" copilot instruction had incorrect Docker mount syntax for Windows PowerShell that resulted in:
```
mount denied: the source path "...:...:ro" too many colons
```

**Root Cause**: Windows file paths include drive letters (e.g., `C:\...`). Using `-v $configFile:$configFile:ro` expanded to too many colons for Docker's mount parser.

**Solution**: Mount to a container path instead:
```powershell
docker compose run --rm -v "$configFile`:/app/config.json:ro" ingestion ...
```

**Changes**:
- Updated `.github/copilot-instructions.md` line 207 to use proper Windows-compatible mount syntax

### Issue #330: Parsing Service Error Reporter AttributeError  
**Problem**: Parsing service crashed with `AttributeError: 'ConsoleErrorReporter' object has no attribute 'capture_exception'`

**Root Cause**: Parsing service called non-existent `capture_exception()` method instead of `report()` method defined in ErrorReporter interface.

**Solution**: Replace `capture_exception()` with `report(error, context=...)`

**Changes**:
- Updated `parsing/app/service.py` line 260 in `_publish_parsing_failed()` 
- Updated `parsing/app/service.py` line 517 in exception handler
- Now properly passes archive_id context to error reporter

**Testing**:
- ✅ All 29 parsing unit tests pass
- ✅ Parsing service healthy and running
- ✅ Error reporter properly captures exceptions

## Related Issues

Fixes #329
Fixes #330

## Type of Change

- [x] Bug fix (fixes existing issues)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing Performed

- Parsing unit tests: 29/29 passing
- Service health checks: All healthy
- Integration testing: IETF mailing list ingestion proceeds without AttributeError
