### PR TITLE
Handle missing thread roots gracefully to avoid KeyError

### DIFF
--- a/parsing/app/thread_builder.py
+++ b/parsing/app/thread_builder.py
@@ -48,7 +48,10 @@ class ThreadBuilder:
         for message in messages:
             message_id = message["message_id"]
             root = self._find_thread_root(message_id, message_map, roots)
-            root_doc_id = message_map[root].get("_id", root)  # Use root message's canonical _id
+            # If the root isn't present in the parsed set (e.g., missing parent), fall back to the raw ID.
+            if root not in message_map:
+                logger.warning("Root message %s not found in parsed set; using raw ID", root)
+            root_doc_id = message_map.get(root, {}).get("_id", root)
             thread_assignments[message_id] = root_doc_id
             # Update the message's thread_id to root message's canonical _id
             message["thread_id"] = root_doc_id


### PR DESCRIPTION
This pull request makes a small but important improvement to the thread-building logic in `thread_builder.py`. It adds a check to handle cases where a root message is missing from the parsed set, logging a warning and falling back to using the raw ID.

- Thread assignment robustness:
  * [`parsing/app/thread_builder.py`](diffhunk://#diff-45ee62aa467e4fcff07a10b0279f0ca92585e0d0e5c31ca2facec503c420f45aL51-R54): Added a check to log a warning when a root message is not found in the parsed set and updated the logic to safely fall back to the raw ID for the thread assignment.