### PR TITLE
Fallback to message _id when parent missing to keep thread_ids valid

### DIFF
--- a/parsing/app/thread_builder.py
+++ b/parsing/app/thread_builder.py
@@ -48,7 +48,13 @@ class ThreadBuilder:
         for message in messages:
             message_id = message["message_id"]
             root = self._find_thread_root(message_id, message_map, roots)
-            root_doc_id = message_map[root].get("_id", root)  # Use root message's canonical _id
+            if root not in message_map:
+                logger.warning("Root message %s not found; using current message _id as thread root", root)
+                # Fall back to the current message's canonical _id so thread_ids stay valid hex IDs
+                root_doc_id = message.get("_id", message_id)
+                roots.add(message_id)
+            else:
+                root_doc_id = message_map[root].get("_id", root)  # Use root message's canonical _id
             thread_assignments[message_id] = root_doc_id
             # Update the message's thread_id to root message's canonical _id
             message["thread_id"] = root_doc_id


### PR DESCRIPTION
This pull request improves the robustness of the thread-building logic in `thread_builder.py` by handling cases where a thread root message is missing from the message map. If the root message is not found, the code now logs a warning and uses the current message's ID as the thread root to ensure thread IDs remain valid.

Error handling and logging improvements:

* Added a check in `build_threads` to detect when a root message is missing from `message_map`, log a warning, and fall back to using the current message's `_id` as the thread root to maintain valid thread IDs.