### PR TITLE
auth: Grant reader role to bootstrapped admin user

### DIFF
--- a/auth/app/role_store.py
+++ b/auth/app/role_store.py
@@ -144,12 +144,13 @@ class RoleStore:
 
         # Special case: auto-promote first user to admin if no admins exist
         # Only if explicitly enabled (disabled by default for production security)
+        # Admin users also get reader role for basic access to reporting endpoints
         if first_user_auto_promotion_enabled:
             admins = self.find_by_role("admin")
             if not admins:
-                roles = ["admin"]
+                roles = ["admin", "reader"]
                 status = "approved"
-                logger.info(f"Auto-promoting first user {user.id} to admin role (no admins exist)")
+                logger.info(f"Auto-promoting first user {user.id} to admin and reader roles (no admins exist)")
 
         # If auto-promotion didn't happen, check normal auto-approval
         if not roles:


### PR DESCRIPTION
## Description

Fixes #592 

This PR ensures that the first user to authenticate (when `FIRST_USER_AUTO_PROMOTION_ENABLED=true`) receives both the `admin` and `reader` roles instead of just `admin`. This allows the bootstrapped admin to access reporting endpoints that require the `reader` role.

## Changes

- Modified `auth/app/role_store.py` to assign `["admin", "reader"]` during first-user auto-promotion
- Updated log message to reflect both roles being assigned

## Why This Fix is Needed

Without the `reader` role:
- Bootstrapped admin cannot access `/reporting/api/sources` or `/reporting/api/reports`
- API requests return 403 Forbidden with log: `"User missing required role", "required_role": "reader", "user_roles": ["admin"]`
- Admin must manually assign themselves the `reader` role via admin API

## Testing

After this fix:
1. Clean slate: delete existing user_roles records in MongoDB
2. Restart auth service with updated code
3. First user to log in will receive `["admin", "reader"]` roles
4. User can successfully access reporting endpoints

## Related Issues

- Fixes #592
- Related to #591 (SPA auth loop when roles missing)