### PR TITLE
Rollback Grafana SSO: disable JWT and revert gateway headers

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -87,32 +87,10 @@ services:
       - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:8080/grafana/}
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
       
-      # JWT Authentication Configuration
-      # Enables JWT-based authentication for seamless SSO
-      - GF_AUTH_JWT_ENABLED=true
-      # Header containing JWT token (Nginx will pass Authorization header)
-      - GF_AUTH_JWT_HEADER_NAME=Authorization
-      # JWT claim mapping to Grafana user attributes
-      - GF_AUTH_JWT_EMAIL_CLAIM=email
-      - GF_AUTH_JWT_USERNAME_CLAIM=sub
-      - GF_AUTH_JWT_NAME_CLAIM=name
-      # Path to admin claim in JWT (checks if 'admin' role exists in roles array)
-      - GF_AUTH_JWT_ROLE_ATTRIBUTE_PATH=contains(roles[*], 'admin')
-      - GF_AUTH_JWT_ROLE_ATTRIBUTE_STRICT=false
-      
-      # JWT Validation: Use JWKS endpoint for key fetching and validation
-      # Must use HTTPS scheme as required by Grafana JWT authentication
-      # Using gateway (nginx) for HTTPS; self-signed certs used internally
-      - GF_AUTH_JWT_JWK_SET_URL=https://gateway:8443/auth/.well-known/jwks.json
-      # Skip certificate verification for internal self-signed certs
-      - GF_AUTH_JWT_TLS_SKIP_VERIFY_INSECURE=true
-      # Cache JWKS for 1 hour to reduce auth service load
-      - GF_AUTH_JWT_CACHE_TTL=3600
-      
-      # Auto-login via JWT token
-      - GF_AUTH_JWT_AUTO_SIGN_UP=true
-      # Allow JWT to assign Grafana Admin role based on admin claim
-      - GF_AUTH_JWT_ALLOW_ASSIGN_GRAFANA_ADMIN=true
+      # SSO Rollback: Disable JWT-based authentication for Grafana
+      # (Dec 29, 2025) Temporarily rely on local admin credentials
+      # until a robust auth_proxy/cookie-based approach is implemented.
+      # NOTE: All GF_AUTH_JWT_* variables removed as part of rollback.
       
       # User account defaults
       - GF_USERS_ALLOW_SIGN_UP=false

--- a/docs/GRAFANA_JWT_IMPLEMENTATION.md
+++ b/docs/GRAFANA_JWT_IMPLEMENTATION.md
@@ -3,6 +3,8 @@
 
 # JWT Token Authentication for Grafana - Implementation Summary
 
+> Status: Rolled back on Dec 29, 2025 — JWT SSO is temporarily disabled. Grafana currently uses local admin authentication via Docker secrets. This document remains for reference and future re‑implementation plans (e.g., auth_proxy or cookie-based SSO).
+
 ## Overview
 
 This implementation adds JWT token-based authentication to Grafana, enabling seamless SSO integration with the existing OAuth/OIDC auth service. Users authenticate once via OAuth/OIDC and can access Grafana without a separate login, including when clicking Grafana links in the UI.

--- a/docs/GRAFANA_JWT_TESTING.md
+++ b/docs/GRAFANA_JWT_TESTING.md
@@ -3,6 +3,8 @@
 
 # Testing JWT Authentication for Grafana
 
+> Status: Rolled back on Dec 29, 2025 — JWT SSO is temporarily disabled. The testing steps below are deprecated for the current deployment. Use local Grafana admin credentials as a temporary workaround until SSO is re‑implemented.
+
 This document describes how to test the JWT authentication implementation for Grafana.
 
 ## Prerequisites

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -117,7 +117,7 @@ http {
       proxy_redirect off;
     }
 
-    # Grafana (served from subpath) with JWT token support
+    # Grafana (served from subpath)
     location /grafana/ {
       proxy_http_version 1.1;
       # Preserve original host and forward explicit host header
@@ -127,15 +127,6 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Prefix /grafana;
-      
-      # JWT Authentication for Grafana SSO
-      # Uses $auth_header mapped variable (defined at http level)
-      # Priority order:
-      # 1. Use Authorization header if provided (for API calls)
-      # 2. Otherwise, extract JWT from auth_token cookie (for browser navigation)
-      # This enables SSO when users click Grafana links, as browsers automatically
-      # send cookies but cannot send custom Authorization headers during navigation.
-      proxy_set_header Authorization $auth_header;
       
       # Preserve original request URI (including /grafana/) to avoid redirect loops
       proxy_pass http://grafana:3000;


### PR DESCRIPTION
## Summary
Temporarily roll back Grafana SSO and disable JWT integration to restore a stable experience. This removes all `GF_AUTH_JWT_*` configuration from Grafana and reverts the gateway `/grafana/` proxy to stop forwarding Authorization headers. Tracks: #632.

## Changes
- docker-compose.infra.yml: remove all `GF_AUTH_JWT_*` vars; add rollback note.
- infra/nginx/nginx.conf: remove `proxy_set_header Authorization $auth_header` and JWT SSO comments in `/grafana/` block.
- docs/GRAFANA_JWT_IMPLEMENTATION.md: add rollback status note.
- docs/GRAFANA_JWT_TESTING.md: mark JWT testing as deprecated during rollback.

## Rationale
Current JWT SSO path is broken for standard browser navigation. Until we implement a robust approach (auth_proxy or cookie-based session), we prefer reliable local auth via admin credentials.

## Validation
- `docker compose config` validates successfully after changes.
- Access via `http://localhost:8080/grafana/` should present Grafana login and accept admin credentials from Docker secrets.

## Follow-up
- Evaluate `auth_proxy` with gateway-side JWT validation and trusted headers (or cookie-based approach).

## Checklist
- [x] No JWT env vars for Grafana
- [x] Gateway no longer injects Authorization header for `/grafana/`
- [x] Docs reflect rollback status

Co-authored-by: GitHub Copilot <noreply@github.com>