### PR TITLE
fix: remove amd64-only pinned digests to enable arm64 builds

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -4,7 +4,7 @@
 # Authentication Service Dockerfile
 # Single-stage build aligned with other services
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/chunking/Dockerfile
+++ b/chunking/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 # Install rsync for archive fetching
 RUN apt-get update && \

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/parsing/Dockerfile
+++ b/parsing/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 WORKDIR /app
 

--- a/summarization/Dockerfile
+++ b/summarization/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Copilot-for-Consensus contributors
 
-FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
+FROM python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The Docker image build for arm64 was failing with:
```
.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture
```

## Root Cause

Six Dockerfiles were pinned to an amd64-only digest of `python:3.11-slim`:
```dockerfile
FROM python:3.11-slim@sha256:158caf0e080e2cd74ef2879ed3c4e697792ee65251c8208b7afb56683c32ea6c
```

When building for arm64, Docker Buildx tried to run this amd64 binary via QEMU emulation, which failed.

## Solution

Removed the digest pin to allow Docker to pull the correct multi-arch variant:
```dockerfile
FROM python:3.11-slim
```

Docker will automatically select the appropriate architecture (amd64 or arm64) for each platform.

## Affected Services

- auth
- chunking  
- ingestion
- orchestrator
- parsing
- summarization

## Testing

This should enable successful arm64 builds in the `publish-docker-images` workflow. The workflow can now build and publish multi-arch images for all services (except embedding, which remains amd64-only).