### PR TITLE
ci: temporarily disable arm64 builds until base image digest issue is resolved

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -34,11 +34,11 @@ jobs:
           - name: auth
             context: .
             dockerfile: ./auth/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: chunking
             context: .
             dockerfile: ./chunking/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: embedding
             context: .
             dockerfile: ./embedding/Dockerfile
@@ -46,31 +46,31 @@ jobs:
           - name: ingestion
             context: .
             dockerfile: ./ingestion/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: orchestrator
             context: .
             dockerfile: ./orchestrator/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: parsing
             context: .
             dockerfile: ./parsing/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: reporting
             context: .
             dockerfile: ./reporting/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: summarization
             context: .
             dockerfile: ./summarization/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: ui
             context: ./ui
             dockerfile: ./ui/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - name: gateway
             context: ./infra/nginx
             dockerfile: ./infra/nginx/Dockerfile
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Temporarily disables arm64 builds in the `publish-docker-images` workflow while maintaining security with pinned base image digests.

## Problem

Docker builds were failing for arm64 with:
```
.buildkit_qemu_emulator: /bin/sh: Invalid ELF image for this architecture
```

Root cause: The pinned `python:3.11-slim` digest (used for security) is amd64-only and doesn't support arm64.

## Solution

Changed all services from `linux/amd64,linux/arm64` to `linux/amd64` only:
- auth, chunking, ingestion, orchestrator, parsing, summarization
- ui, gateway
- reporting, embedding

This preserves supply chain security (pinned digests) while fixing the build failures.

## Tracking

Related issue: #675 - "Support multi-arch (arm64) Docker builds with pinned digests"

The issue tracks finding or updating base image digests that support both architectures while maintaining digest pinning for security.

## Testing

- Workflow should now complete successfully for all services
- All published images will be amd64 only
- No functional changes to any service