### PR TITLE
fix: Add retry logic to JWT keys deployment for RBAC propagation

### DIFF
--- a/infra/azure/modules/jwtkeys.bicep
+++ b/infra/azure/modules/jwtkeys.bicep
@@ -132,19 +132,10 @@ $publicStored = $false
 Write-Host "Storing JWT keys in Key Vault (with retry for RBAC propagation)..."
 
 for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
-  if ($privateStored -and $publicStored) {
-    Write-Host "JWT keys generated and stored successfully (attempt $attempt)"
-    break
-  }
-
   try {
     if (-not $privateStored) {
       Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $privateSecretName -SecretValue (ConvertTo-SecureString -String $privateKeyFormatted -AsPlainText -Force) -ErrorAction Stop | Out-Null
       $privateStored = $true
-      if ($privateStored -and $publicStored) {
-        Write-Host "JWT keys generated and stored successfully (attempt $attempt)"
-        break
-      }
     }
   }
   catch {
@@ -156,15 +147,16 @@ for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
     if (-not $publicStored) {
       Set-AzKeyVaultSecret -VaultName $keyVaultName -Name $publicSecretName -SecretValue (ConvertTo-SecureString -String $publicKeyFormatted -AsPlainText -Force) -ErrorAction Stop | Out-Null
       $publicStored = $true
-      if ($privateStored -and $publicStored) {
-        Write-Host "JWT keys generated and stored successfully (attempt $attempt)"
-        break
-      }
     }
   }
   catch {
     $errorMessage = $_.Exception.Message
     if (Handle-SecretError -errorMessage $errorMessage -attempt $attempt -maxRetries $maxRetries -retryDelay $retryDelay) { continue }
+  }
+
+  if ($privateStored -and $publicStored) {
+    Write-Host "JWT keys generated and stored successfully (attempt $attempt)"
+    break
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes race condition where JWT keys deployment script fails with `ParentResourceNotFound` error due to Azure RBAC permissions not yet propagated.

## Problem
Azure RBAC permissions can take up to 5 minutes to propagate after role assignment creation. The JWT keys deployment script was failing immediately when trying to write secrets to Key Vault, despite the `secretWriterRoleAssignments` role being correctly assigned in [keyvault.bicep](https://github.com/Alan-Jowett/CoPilot-For-Consensus/blob/main/infra/azure/modules/keyvault.bicep).

## Solution
Added retry logic to the PowerShell deployment script in `jwtkeys.bicep`:
- **20 retries × 30 seconds = 10 minutes maximum wait**
- Catches permission-related errors: `Forbidden`, `ParentResourceNotFound`, `not authorized`, `does not have secrets set permission`
- Waits 30 seconds between retries with clear warning messages
- Fails immediately on non-permission errors (e.g., network issues, invalid parameters)

## Changes
- `infra/azure/modules/jwtkeys.bicep`: Added retry loop around `Set-AzKeyVaultSecret` calls

## Testing
Will test with deployment to fresh resource group to verify RBAC propagation is handled correctly.

## Related Issues
- Resolves persistent deployment failures seen in copilot-consensus-dev-rg and copilot-consensus-dev-01
- Related to PR #681 which added the RBAC role assignments