### PR TITLE
Point UI container app to port 80

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -91,7 +91,7 @@ var servicePorts = {
   embedding: 8000
   orchestrator: 8000
   summarization: 8000
-  ui: 3000
+  ui: 80
   gateway: 8080
 }
 


### PR DESCRIPTION
## Summary
- Set `servicePorts.ui` to 80 so Container App ingress and gateway UI_BACKEND target the port nginx actually listens on
- Resolves timeouts from gateway `/ui` when calling UI service

## Testing
- Not run (infra config change)

Fixes #689