### PR TITLE
fix: gateway HTTP backend routing and replica scaling for debugging

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -198,7 +198,6 @@ resource authApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        // Gateway should stay warm to serve external traffic
         minReplicas: 1
         maxReplicas: 2
       }
@@ -277,7 +276,6 @@ resource reportingApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        // Keep UI warm so gateway can always route
         minReplicas: 1
         maxReplicas: 2
       }

--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -82,9 +82,9 @@ var projectPrefix = take(replace(projectName, '-', ''), 8)
 var caEnvName = '${projectPrefix}-env-${environment}-${take(uniqueSuffix, 5)}'
 
 // Scale-to-zero configuration for cost optimization in dev environment
-// Dev: minReplicas = 0 (scale to zero when idle, accepting cold-start latency)
+// Dev: minReplicas = 1 (keep running during debugging to see startup failures)
 // Staging/Prod: minReplicas = 1 (maintain at least one replica for faster response times)
-var minReplicaCount = environment == 'dev' ? 0 : 1
+var minReplicaCount = 1
 
 // Service port mappings (internal container listen ports)
 // Note: Gateway uses 8080 internally; Container Apps platform handles TLS termination and exposes externally on 443
@@ -198,7 +198,8 @@ resource authApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: minReplicaCount
+        // Gateway should stay warm to serve external traffic
+        minReplicas: 1
         maxReplicas: 2
       }
     }
@@ -276,7 +277,8 @@ resource reportingApp 'Microsoft.App/containerApps@2024-03-01' = {
         }
       ]
       scale: {
-        minReplicas: minReplicaCount
+        // Keep UI warm so gateway can always route
+        minReplicas: 1
         maxReplicas: 2
       }
     }
@@ -914,7 +916,7 @@ resource gatewayApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: true
         targetPort: servicePorts.gateway
         allowInsecure: false
-        transport: 'auto'
+        transport: 'http'
       }
     }
     template: {


### PR DESCRIPTION
## Problem
Gateway was returning 502 Bad Gateway when accessing `/ui/` endpoint through Azure Container Apps. Root cause: gateway configuration and service scaling issues.

## Changes Made

### 1. Set minReplicas to 1 (constant)
Changed from `environment == 'dev' ? 0 : 1` to constant `1`:
- Ensures all services stay warm during debugging to avoid cold-start failures
- Prevents scale-to-zero latency when gateway tries to route traffic
- Adds comment clarifying gateway should stay warm to serve external traffic

### 2. Fix gateway ingress transport
Changed gateway ingress transport from `'auto'` to explicit `'http'`:
- Matches internal Container Apps networking model where all communication is HTTP
- Prevents ambiguous protocol negotiation during startup
- TLS termination is handled by Azure's ingress layer, not internal services

## Why These Changes Help
The original issue was 502 Bad Gateway errors with nginx showing "peer closed connection in SSL handshake". Root causes:
1. Gateway container couldn't connect when services were scaled to zero
2. Implicit `'auto'` transport negotiation was causing SSL confusion during startup

## Note on Backend URLs
Gateway backend URLs were already configured correctly for internal HTTP communication:
- `http://${projectPrefix}-reporting-${environment}:${servicePorts.reporting}`
- `http://${projectPrefix}-auth-${environment}:${servicePorts.auth}`
- `http://${projectPrefix}-ingestion-${environment}:${servicePorts.ingestion}`
- `http://${projectPrefix}-ui-${environment}:${servicePorts.ui}`

No changes to backend URLs were needed.

## Files Modified
- `infra/azure/modules/containerapps.bicep`

## Next Steps
Run `.github/workflows/publish-docker-images.yml` to rebuild gateway image, then redeploy Azure environment.