### PR TITLE
fix: resolve YAML syntax error in openapi-validation workflow

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -233,14 +233,14 @@ jobs:
           fi
           
           # Create a summary
-          cat > /tmp/spec-bundle/README.md << 'EOF'
+          cat > /tmp/spec-bundle/README.md << EOF
 # OpenAPI Specification Bundle
 
 This bundle contains OpenAPI specifications for the Copilot-for-Consensus system.
 
 ## Files
 
-- `gateway.yaml` - Public API Gateway specification (spec-first)
+- gateway.yaml - Public API Gateway specification (spec-first)
 - Service specs (if generated): reporting.yaml, ingestion.yaml, auth.yaml, orchestrator.yaml
 
 ## Generation


### PR DESCRIPTION
## Description

Fixes the YAML syntax error in `.github/workflows/openapi-validation.yml` that was preventing the workflow from validating.

## Changes

- Remove single quotes from heredoc delimiter (`<< 'EOF'` → `<< EOF`)
- This allows GitHub Actions to properly expand `${{ }}` expressions in the generated README

## Why

When using single quotes around the EOF delimiter in a heredoc, the shell treats the content literally and doesn't expand variables. This causes GitHub Actions to fail when parsing the workflow because the `${{ github.workflow }}` and `${{ github.run_number }}` expressions can't be expanded.

## Testing

The workflow should now validate without YAML syntax errors.