### PR TITLE
Refactor README.md in OpenAPI specification bundle

### DIFF
--- a/.github/workflows/openapi-validation.yml
+++ b/.github/workflows/openapi-validation.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install openapi-spec-validator pyyaml fastapi uvicorn pydantic
-          # Install service-specific dependencies (adapters already installed)
+          # Install service-specific dependencies
           if [ -f ${{ matrix.service }}/requirements.txt ]; then
             echo "Installing ${{ matrix.service }} dependencies..."
             pip install -r ${{ matrix.service }}/requirements.txt
@@ -112,18 +112,15 @@ jobs:
       - name: Check if spec was generated
         run: |
           if [ ! -f "openapi/generated/${{ matrix.service }}.yaml" ]; then
-            echo "⚠️  Spec generation failed for ${{ matrix.service }}"
-            echo "This usually means:"
-            echo "  1. Service has import errors"
-            echo "  2. Service dependencies are missing (expected in CI)"
-            echo "  3. FastAPI app is not properly defined"
+            echo "❌ Spec generation failed for ${{ matrix.service }}"
+            echo "Spec generation is required. Please ensure:"
+            echo "  1. Service has no import errors"
+            echo "  2. All service dependencies are installed"
+            echo "  3. FastAPI app is properly defined"
             echo ""
-            echo "To generate specs locally, run:"
-            echo "  ./scripts/generate_service_openapi.py --service ${{ matrix.service }}"
-            echo ""
-            echo "Note: Spec generation requires full service dependencies."
-            echo "CI validation will be skipped for this service."
-            exit 0
+            echo "To test locally:"
+            echo "  python scripts/generate_service_openapi.py --service ${{ matrix.service }} --validate"
+            exit 1
           fi
           echo "✓ Successfully generated openapi/generated/${{ matrix.service }}.yaml"
       
@@ -227,29 +224,32 @@ jobs:
             find /tmp/all-specs -name "*.yaml" -exec cp {} /tmp/spec-bundle/ \; 2>/dev/null || true
           fi
           
-          # Create a summary (indent for YAML; strip indentation via sed)
-          cat << EOF | sed 's/^          //' > /tmp/spec-bundle/README.md
-          # OpenAPI Specification Bundle
-          
-          This bundle contains OpenAPI specifications for the Copilot-for-Consensus system.
-          
-          ## Files
-          
-          - gateway.yaml - Public API Gateway specification (spec-first)
-          - Service specs (if generated): reporting.yaml, ingestion.yaml, auth.yaml, orchestrator.yaml
-          
-          ## Generation
-          
-          - Gateway spec: Manually maintained in repository
-          - Service specs: Auto-generated from FastAPI service definitions
-          - Workflow: ${{ github.workflow }}
-          - Run: ${{ github.run_number }}
-          
-          ## Note
-          
-          Service specs may not be included if they couldn't be generated due to missing dependencies in CI.
-          To generate service specs locally, see docs/openapi.md
-          EOF
+          # Create spec bundle README
+          cat > /tmp/spec-bundle/README.md << 'EOF'
+# OpenAPI Specification Bundle
+
+This bundle contains OpenAPI specifications for the Copilot-for-Consensus system.
+
+## Files
+
+- gateway.yaml - Public API Gateway specification (spec-first)
+- reporting.yaml - Reporting service OpenAPI specification
+- ingestion.yaml - Ingestion service OpenAPI specification
+- auth.yaml - Authentication service OpenAPI specification
+- orchestrator.yaml - Orchestrator service OpenAPI specification
+
+## Generation
+
+- Gateway spec: Manually maintained in repository
+- Service specs: Auto-generated from FastAPI service definitions
+- Workflow: ${{ github.workflow }}
+- Run: ${{ github.run_number }}
+
+## Note
+
+All service specifications must be successfully generated in CI. If any spec is missing,
+the workflow will fail. To generate specs locally, see docs/openapi.md
+EOF
           
           echo "Spec bundle contents:"
           ls -lh /tmp/spec-bundle/


### PR DESCRIPTION
## Update
- Revert stub-spec fallback and make service spec generation fatal again.
- Workflow now fails if a service spec cannot be generated; validation/metadata/upload always run on the generated file.

## Changes
- `scripts/generate_service_openapi.py`: remove stub emission and exit non-zero on generation failures.
- `.github/workflows/openapi-validation.yml`: generation step is no longer `continue-on-error`, and validation/metadata/upload are unconditional (spec must exist).

## Rationale
We must produce real OpenAPI specs for validation; missing specs are now fatal in CI.
