### PR TITLE
Fix AUTH_SERVICE_URL to remove port for Container Apps internal ingress

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -306,7 +306,7 @@ resource reportingApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -416,7 +416,7 @@ resource ingestionApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -511,7 +511,7 @@ resource parsingApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -606,7 +606,7 @@ resource chunkingApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -733,7 +733,7 @@ resource embeddingApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -844,7 +844,7 @@ resource orchestratorApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -971,7 +971,7 @@ resource summarizationApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'AUTH_SERVICE_URL'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
@@ -1097,19 +1097,19 @@ resource gatewayApp 'Microsoft.App/containerApps@2024-03-01' = {
             }
             {
               name: 'REPORTING_BACKEND'
-              value: 'http://${projectPrefix}-reporting-${environment}:${servicePorts.reporting}'
+              value: 'http://${projectPrefix}-reporting-${environment}'
             }
             {
               name: 'AUTH_BACKEND'
-              value: 'http://${projectPrefix}-auth-${environment}:${servicePorts.auth}'
+              value: 'http://${projectPrefix}-auth-${environment}'
             }
             {
               name: 'INGESTION_BACKEND'
-              value: 'http://${projectPrefix}-ingestion-${environment}:${servicePorts.ingestion}'
+              value: 'http://${projectPrefix}-ingestion-${environment}'
             }
             {
               name: 'UI_BACKEND'
-              value: 'http://${projectPrefix}-ui-${environment}:${servicePorts.ui}'
+              value: 'http://${projectPrefix}-ui-${environment}'
             }
             {
               name: 'ENABLE_INTERNAL_TLS'


### PR DESCRIPTION
## Problem

Services in Azure Container Apps were unable to fetch JWKS from the auth service, causing authentication failures during startup. The ingestion and reporting services logged:

```
JWKS fetch attempt 1/5 failed: ConnectTimeout - timed out
```

After testing, we discovered that:
- ✅ `http://copilot-auth-dev/keys` works
- ❌ `http://copilot-auth-dev:8090/keys` times out

## Root Cause

Azure Container Apps internal ingress exposes services on port 80 (default HTTP), not on the container's `targetPort` (8090). The ingress layer automatically handles port mapping, so services should connect without specifying the port.

## Solution

Removed the port specification from all internal service URLs:

**AUTH_SERVICE_URL changes (7 services):**
- reporting, ingestion, parsing, chunking, embedding, orchestrator, summarization
- Changed from: `http://copilot-auth-dev:8090`
- Changed to: `http://copilot-auth-dev`

**Gateway backend URLs (4 services):**
- AUTH_BACKEND, REPORTING_BACKEND, INGESTION_BACKEND, UI_BACKEND
- Removed ports from all backend URLs for consistency

## Validation

After applying the fix, the ingestion service logs show successful JWKS fetch:

```
Successfully fetched JWKS from http://copilot-auth-dev/keys (1 keys) on attempt 1/5
```

## Files Changed

- `infra/azure/modules/containerapps.bicep`: Updated AUTH_SERVICE_URL and gateway backend URLs (11 changes)

Resolves #743