### PR TITLE
feat: Add custom domain support for Container Apps gateway

### DIFF
--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -522,9 +522,12 @@ module azureDnsModule 'modules/azuredns.bicep' = if (deployContainerApps && !emp
   params: {
     dnsZoneName: azureDnsZoneName
     customDomainName: customDomainName
-    gatewayFqdn: containerAppsModule!.outputs.gatewayFqdn
+    gatewayFqdn: containerAppsModule!.outputs.defaultGatewayFqdn
     tags: tags
   }
+  dependsOn: [
+    containerAppsModule
+  ]
 }
 
 // Calculate redirect URIs for OAuth callback

--- a/infra/azure/modules/azuredns.bicep
+++ b/infra/azure/modules/azuredns.bicep
@@ -16,9 +16,11 @@ param gatewayFqdn string
 @description('Resource tags')
 param tags object = {}
 
-// Extract subdomain name from custom domain
+// Extract subdomain name from custom domain with validation
 // e.g., "copilot.example.com" with zone "example.com" → "copilot"
-var subdomainName = take(customDomainName, length(customDomainName) - length(dnsZoneName) - 1)
+var subdomainName = endsWith(customDomainName, dnsZoneName) && length(customDomainName) > length(dnsZoneName) + 1
+  ? take(customDomainName, length(customDomainName) - length(dnsZoneName) - 1)
+  : customDomainName
 
 // Create or reference existing DNS Zone
 resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {

--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -86,10 +86,10 @@ param logAnalyticsWorkspaceId string
 @description('Log Analytics workspace customerId (GUID)')
 param logAnalyticsCustomerId string
 
-@description('Custom domain name for the gateway (e.g., copilot.example.com). Leave empty to use default Container Apps domain.')
+@description('Custom domain name for the gateway (e.g., copilot.example.com). Leave empty to use default Container Apps domain. Must be provided together with customDomainCertificateId.')
 param customDomainName string = ''
 
-@description('TLS certificate resource ID for custom domain (managed certificate from Container Apps environment). Leave empty if using default domain.')
+@description('TLS certificate resource ID for custom domain (managed certificate from Container Apps environment). Leave empty if using default domain. Must be provided together with customDomainName.')
 param customDomainCertificateId string = ''
 
 param tags object = {}
@@ -1111,7 +1111,7 @@ resource gatewayApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: servicePorts.gateway
         allowInsecure: false
         transport: 'http'
-        customDomains: customDomainName != '' ? [
+        customDomains: customDomainName != '' && customDomainCertificateId != '' ? [
           {
             name: customDomainName
             certificateId: customDomainCertificateId
@@ -1182,11 +1182,14 @@ resource gatewayApp 'Microsoft.App/containerApps@2024-03-01' = {
 @description('Container Apps Environment ID')
 output containerAppsEnvId string = containerAppsEnv.id
 
-@description('Gateway FQDN for external access')
-output gatewayFqdn string = customDomainName != '' ? customDomainName : gatewayApp.properties.configuration.ingress.fqdn
+@description('Gateway FQDN for external access (custom domain if configured, otherwise default Container Apps FQDN)')
+output gatewayFqdn string = customDomainName != '' && customDomainCertificateId != '' ? customDomainName : gatewayApp.properties.configuration.ingress.fqdn
+
+@description('Default Container Apps gateway FQDN (always returns the Azure-assigned FQDN)')
+output defaultGatewayFqdn string = gatewayApp.properties.configuration.ingress.fqdn
 
 @description('GitHub OAuth redirect URI (computed from gateway FQDN)')
-output githubOAuthRedirectUri string = 'https://${customDomainName != '' ? customDomainName : gatewayApp.properties.configuration.ingress.fqdn}/ui/callback'
+output githubOAuthRedirectUri string = 'https://${customDomainName != '' && customDomainCertificateId != '' ? customDomainName : gatewayApp.properties.configuration.ingress.fqdn}/ui/callback'
 
 @description('Container App resource IDs by service')
 output appIds object = {


### PR DESCRIPTION
## Description

Add support for configuring custom domains (e.g., `copilot.example.com`) for the API Gateway service in Azure Container Apps. Supports both **automated Azure DNS** and **manual DNS** configuration approaches.

## Enhancement: Azure DNS Automation

This PR now includes an optional **Azure DNS module** that fully automates CNAME record management via Infrastructure as Code. This simplifies the setup from 5 manual steps to a single deployment parameter:

```powershell
# Automated approach - single deployment command
az deployment group create \
  --resource-group cfc-dev-02-rg \
  --template-file infra/azure/main.bicep \
  --parameters infra/azure/parameters.dev.json \
  --parameters \
    customDomainName=copilot.example.com \
    customDomainCertificateId=<cert-id> \
    azureDnsZoneName=example.com
```

## Changes

### New Azure DNS Module (`infra/azure/modules/azuredns.bicep`)
- Manages Azure DNS Zone and CNAME record creation
- Automatically extracts subdomain from fully qualified domain name
- Creates CNAME record pointing custom domain to Container Apps gateway FQDN
- Conditional deployment: only created when `azureDnsZoneName` parameter is provided

### Bicep Configuration Updates (`infra/azure/main.bicep`)
- Added `azureDnsZoneName` and `azureDnsResourceGroup` parameters
- Added conditional `azureDnsModule` deployment
- Module output includes DNS record details for validation

### Gateway Configuration (`infra/azure/modules/containerapps.bicep`)
- Added `customDomainName` and `customDomainCertificateId` parameters
- Gateway ingress conditionally configures custom domain with SNI-enabled TLS binding
- Updated `gatewayFqdn` and `githubOAuthRedirectUri` outputs to use custom domain when provided

### Documentation (`docs/CUSTOM_DOMAIN_SETUP.md`)
- **Option 1: Automated Azure DNS Setup** (recommended) - Infrastructure as Code approach
- **Option 2: Manual DNS Setup** - For external DNS providers or non-Azure DNS hosting
- Comprehensive setup guides for both approaches with step-by-step instructions
- OAuth redirect URI updates for GitHub and Entra ID
- Troubleshooting section and security recommendations

## How It Works

### Automated (Azure DNS)
1. Create managed certificate in Container Apps environment
2. Deploy with custom domain + Azure DNS zone parameters
3. Bicep module automatically:
   - ✅ Creates CNAME record in Azure DNS
   - ✅ Extracts subdomain from domain name
   - ✅ Configures SNI-enabled TLS binding
   - ✅ Outputs DNS record details for validation

### Manual (Any DNS Provider)
1. Create managed certificate in Container Apps environment
2. Manually add CNAME record to your DNS provider
3. Deploy with custom domain parameters only

## Testing

- ✅ Bicep template builds successfully with no errors
- ✅ Parameters validated with default values (no custom domain)
- ✅ Azure DNS module properly declares conditional dependencies
- ✅ Both manual and automated paths fully documented
- ✅ Ready for deployment with either approach

## Backward Compatibility

None. Parameters default to empty strings, maintaining backward compatibility with existing deployments.

## Deployment Notes

- **Automated path**: Requires Azure DNS Zone hosted in Azure DNS
- **Manual path**: Works with any DNS provider
- Requires pre-created managed certificate in Container Apps environment
- DNS configuration must be completed before deploying with custom domain
- Certificate validation must complete before deployment

## Related Issues

- Enables production-ready custom domain setup for gateway service
- Supports OAuth redirect URI configuration (#752)
- Addresses infrastructure as Code best practices for DNS management