### PR TITLE
fix: Set ingestion service HTTP_HOST to 0.0.0.0 for Container Apps

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -424,6 +424,10 @@ resource ingestionApp 'Microsoft.App/containerApps@2024-03-01' = {
               value: string(servicePorts.ingestion)
             }
             {
+              name: 'HTTP_HOST'
+              value: '0.0.0.0'
+            }
+            {
               name: 'AUTH_SERVICE_URL'
               value: 'http://${projectPrefix}-auth-${environment}'
             }


### PR DESCRIPTION
## Problem

Fixes #759

The ingestion service in Azure Container Apps is unreachable through the gateway, causing 503 errors with "Connection refused".

## Root Cause

The ingestion service binds to `127.0.0.1:8001` (localhost only), which prevents the Container Apps ingress proxy from connecting. The service needs to bind to `0.0.0.0` (all interfaces) to accept connections from the platform ingress.

From logs before fix:
```
"Starting HTTP server on 127.0.0.1:8001..."
```

## Solution

Added `HTTP_HOST=0.0.0.0` environment variable to the ingestion service configuration in `containerapps.bicep`.

## Changes

- `infra/azure/modules/containerapps.bicep`: Added `HTTP_HOST` environment variable to ingestion service

## Testing

- ✅ Auth and reporting services already work correctly (bind to 0.0.0.0)
- ✅ Ingestion logs confirmed binding to 127.0.0.1 before fix
- ⏳ After deployment, ingestion should accept connections from gateway
- ⏳ Gateway requests to `/ingestion/health` and `/ingestion/api/sources` should succeed

## Impact

**Before**: All ingestion endpoints return 503, UI cannot manage sources, ingestion completely unavailable in Azure

**After**: Ingestion service accessible through gateway, source management functional

## Deployment Notes

Requires redeployment of ingestion service. Service will restart and bind to `0.0.0.0:8001` instead of `127.0.0.1:8001`.