### PR TITLE
fix: Enable Azure OpenAI deployment in dev environment

### DIFF
--- a/infra/azure/parameters.dev.json
+++ b/infra/azure/parameters.dev.json
@@ -15,7 +15,7 @@
       "value": "latest"
     },
     "deployAzureOpenAI": {
-      "value": false
+      "value": true
     },
     "azureOpenAISku": {
       "value": "S0"


### PR DESCRIPTION
## Problem

Fixes #763

The dev environment has `deployAzureOpenAI: false`, which prevents deployment of any LLM models. After removing the ollama fallback (PR #755), this leaves the dev environment with **no LLM backend at all**, making it impossible to test orchestrator, summarization, or any document processing functionality.

## Solution

Changed `deployAzureOpenAI` from `false` to `true` in `infra/azure/parameters.dev.json`.

## Changes

```diff
- "deployAzureOpenAI": { "value": false }
+ "deployAzureOpenAI": { "value": true }
```

## Impact

**Before**: 
- ❌ No LLM backend in dev
- ❌ Orchestrator fails when trying to generate summaries
- ❌ Summarization service cannot function
- ❌ Cannot test end-to-end document processing

**After**:
- ✅ Azure OpenAI deployed with minimal configuration
- ✅ GPT-4o model available (10 capacity units)
- ✅ text-embedding-ada-002 available (10 capacity units)
- ✅ Can test full document processing pipeline
- ✅ Consistent with staging/prod environments

## Cost Considerations

Dev uses cost-effective configuration:
- **Standard SKU** (not GlobalStandard) - lower cost tier
- **10 capacity units** for both models - minimal allocation
- **Pay-per-token** - only charged for actual usage during testing
- Can scale down or pause when not actively testing

## Testing

After deployment:
- Orchestrator can call Azure OpenAI for document processing
- Summarization service can generate summaries
- End-to-end ingestion → parsing → chunking → embedding → summarization workflow functional

## Deployment Notes

Next deployment to dev environment will provision Azure OpenAI resources. Services will automatically use the deployed endpoint via environment variables.