### PR TITLE
fix(infra): Remove secrets from environment variables, use secret_provider architecture

### DIFF
--- a/adapters/copilot_config/copilot_config/typed_config.py
+++ b/adapters/copilot_config/copilot_config/typed_config.py
@@ -102,7 +102,10 @@ def load_service_config(
                         if value is not None:
                             driver_config_dict[prop_name] = value
                             break
-                    except Exception:
+                    except Exception as e:
+                        import logging
+                        logger = logging.getLogger("copilot_config")
+                        logger.debug(f"Failed to load secret '{candidate}' for property '{prop_name}': {e}")
                         continue
             else:
                 # Field has no source (not env or secret) - apply default if present
@@ -314,7 +317,10 @@ def load_service_config(
                     secret_adapter.driver_config,
                 )
                 secret_provider = SecretConfigProvider(secret_provider=secret_provider_instance)
-        except Exception:
+        except Exception as e:
+            import logging
+            logger = logging.getLogger("copilot_config")
+            logger.warning(f"Failed to initialize secret_provider: {e}. Secrets will not be available.", exc_info=True)
             secret_provider = None
 
     # Phase 3: load full service settings and rebuild adapter configs with secrets resolved

--- a/adapters/copilot_config/copilot_config/typed_config.py
+++ b/adapters/copilot_config/copilot_config/typed_config.py
@@ -105,7 +105,7 @@ def load_service_config(
                     except Exception as e:
                         import logging
                         logger = logging.getLogger("copilot_config")
-                        logger.debug(f"Failed to load secret '{candidate}' for property '{prop_name}': {e}")
+                        logger.debug(f"Failed to load secret")
                         continue
             else:
                 # Field has no source (not env or secret) - apply default if present

--- a/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
+++ b/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
@@ -7,14 +7,14 @@
         "connection_string": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure-connection-string",
+            "secret_name": "azure_connection_string",
             "required": false,
             "description": "Azure Monitor connection string (e.g., InstrumentationKey=... or Connection string)"
         },
         "azure_monitor_instrumentation_key": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure-monitor-instrumentation-key",
+            "secret_name": "azure_monitor_instrumentation_key",
             "required": false,
             "description": "Application Insights instrumentation key"
         },

--- a/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
+++ b/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
@@ -7,14 +7,14 @@
         "connection_string": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure_connection_string",
+            "secret_name": "azure-connection-string",
             "required": false,
             "description": "Azure Monitor connection string (e.g., InstrumentationKey=... or Connection string)"
         },
         "azure_monitor_instrumentation_key": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure_monitor_instrumentation_key",
+            "secret_name": "azure-monitor-instrumentation-key",
             "required": false,
             "description": "Application Insights instrumentation key"
         },

--- a/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
+++ b/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
@@ -7,14 +7,14 @@
         "connection_string": {
             "type": "string",
             "source": "secret",
-            "secret_name": ["appinsights-connection-string", "azure_connection_string"],
+            "secret_name": "azure_connection_string",
             "required": false,
             "description": "Azure Monitor connection string (e.g., InstrumentationKey=... or Connection string)"
         },
         "azure_monitor_instrumentation_key": {
             "type": "string",
             "source": "secret",
-            "secret_name": ["appinsights-instrumentation-key", "azure_monitor_instrumentation_key"],
+            "secret_name": "azure_monitor_instrumentation_key",
             "required": false,
             "description": "Application Insights instrumentation key"
         },

--- a/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
+++ b/docs/schemas/configs/adapters/drivers/metrics/metrics_azure_monitor.json
@@ -7,14 +7,14 @@
         "connection_string": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure_connection_string",
+            "secret_name": ["appinsights-connection-string", "azure_connection_string"],
             "required": false,
             "description": "Azure Monitor connection string (e.g., InstrumentationKey=... or Connection string)"
         },
         "azure_monitor_instrumentation_key": {
             "type": "string",
             "source": "secret",
-            "secret_name": "azure_monitor_instrumentation_key",
+            "secret_name": ["appinsights-instrumentation-key", "azure_monitor_instrumentation_key"],
             "required": false,
             "description": "Application Insights instrumentation key"
         },

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -345,8 +345,9 @@ module appInsightsModule 'modules/appinsights.bicep' = if (deployContainerApps) 
 
 // Store Application Insights secrets securely in Key Vault
 // These must NOT be passed as plaintext environment variables to Container Apps
+// Secret names match schema expectations: azure_monitor_instrumentation_key (via secret_provider)
 resource appInsightsInstrKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (deployContainerApps) {
-  name: '${keyVaultName}/appinsights-instrumentation-key'
+  name: '${keyVaultName}/azure_monitor_instrumentation_key'
   properties: {
     value: appInsightsModule!.outputs.instrumentationKey
     contentType: 'text/plain'
@@ -372,7 +373,7 @@ module jwtKeysModule 'modules/jwtkeys.bicep' = if (deployContainerApps) {
 }
 
 resource appInsightsConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (deployContainerApps) {
-  name: '${keyVaultName}/appinsights-connection-string'
+  name: '${keyVaultName}/azure_connection_string'
   properties: {
     value: appInsightsModule!.outputs.connectionString
     contentType: 'text/plain'

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -345,9 +345,9 @@ module appInsightsModule 'modules/appinsights.bicep' = if (deployContainerApps) 
 
 // Store Application Insights secrets securely in Key Vault
 // These must NOT be passed as plaintext environment variables to Container Apps
-// Secret names match schema expectations: azure_monitor_instrumentation_key (via secret_provider)
+// Secret names use hyphens (KV requirement); secret_provider maps to schema names
 resource appInsightsInstrKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (deployContainerApps) {
-  name: '${keyVaultName}/azure_monitor_instrumentation_key'
+  name: '${keyVaultName}/azure-monitor-instrumentation-key'
   properties: {
     value: appInsightsModule!.outputs.instrumentationKey
     contentType: 'text/plain'
@@ -373,7 +373,7 @@ module jwtKeysModule 'modules/jwtkeys.bicep' = if (deployContainerApps) {
 }
 
 resource appInsightsConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (deployContainerApps) {
-  name: '${keyVaultName}/azure_connection_string'
+  name: '${keyVaultName}/azure-connection-string'
   properties: {
     value: appInsightsModule!.outputs.connectionString
     contentType: 'text/plain'

--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -497,10 +497,7 @@ resource reportingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'AZURE_OPENAI_DEPLOYMENT'
               value: azureOpenAIEmbeddingDeploymentName
             }
-            {
-              name: 'AZURE_OPENAI_API_KEY'
-              value: azureOpenAIApiKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${azureOpenAIApiKeySecretUri})' : ''
-            }
+            // Removed AZURE_OPENAI_API_KEY - loaded via secret_provider from Key Vault
             // Metrics adapter (Azure Monitor)
             {
               name: 'METRICS_TYPE'
@@ -1181,10 +1178,7 @@ resource embeddingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'AZURE_OPENAI_DEPLOYMENT'
               value: azureOpenAIEmbeddingDeploymentName
             }
-            {
-              name: 'AZURE_OPENAI_API_KEY'
-              value: azureOpenAIApiKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${azureOpenAIApiKeySecretUri})' : ''
-            }
+            // Removed AZURE_OPENAI_API_KEY - loaded via secret_provider from Key Vault
             // Metrics adapter (Azure Monitor)
             {
               name: 'METRICS_TYPE'
@@ -1397,10 +1391,7 @@ resource orchestratorApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'AZURE_OPENAI_DEPLOYMENT'
               value: azureOpenAIGpt4DeploymentName
             }
-            {
-              name: 'AZURE_OPENAI_API_KEY'
-              value: azureOpenAIApiKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${azureOpenAIApiKeySecretUri})' : ''
-            }
+            // Removed AZURE_OPENAI_API_KEY - loaded via secret_provider from Key Vault
             // Orchestrator service settings
             {
               name: 'ORCHESTRATOR_HTTP_PORT'
@@ -1622,10 +1613,7 @@ resource summarizationApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'AZURE_OPENAI_API_VERSION'
               value: '2024-02-15-preview'
             }
-            {
-              name: 'AZURE_OPENAI_API_KEY'
-              value: azureOpenAIApiKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${azureOpenAIApiKeySecretUri})' : ''
-            }
+            // Removed AZURE_OPENAI_API_KEY - loaded via secret_provider from Key Vault
             // Metrics adapter (Azure Monitor)
             {
               name: 'METRICS_TYPE'

--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -276,14 +276,8 @@ resource authApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Secret Provider adapter (Azure Key Vault)
             {
               name: 'SECRET_PROVIDER_TYPE'
@@ -512,14 +506,8 @@ resource reportingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'
@@ -673,14 +661,8 @@ resource ingestionApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'
@@ -869,14 +851,8 @@ resource parsingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'
@@ -1018,14 +994,8 @@ resource chunkingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Secret Provider adapter (Azure Key Vault)
             {
               name: 'SECRET_PROVIDER_TYPE'
@@ -1220,14 +1190,8 @@ resource embeddingApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'
@@ -1377,14 +1341,8 @@ resource orchestratorApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'
@@ -1673,14 +1631,8 @@ resource summarizationApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'METRICS_TYPE'
               value: 'azure_monitor'
             }
-            {
-              name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
-              value: appInsightsKeySecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsKeySecretUri})' : ''
-            }
-            {
-              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-              value: appInsightsConnectionStringSecretUri != '' ? '@Microsoft.KeyVault(SecretUri=${appInsightsConnectionStringSecretUri})' : ''
-            }
+            // Removed APPINSIGHTS_INSTRUMENTATIONKEY and APPLICATIONINSIGHTS_CONNECTION_STRING
+            // These secrets are loaded via secret_provider from Key Vault using schema secret_name
             // Error reporter adapter
             {
               name: 'ERROR_REPORTER_TYPE'

--- a/infra/azure/modules/keyvault-rbac.bicep
+++ b/infra/azure/modules/keyvault-rbac.bicep
@@ -66,12 +66,12 @@ resource authJwtPublicKeyAccess 'Microsoft.Authorization/roleAssignments@2022-04
 
 resource appInsightsInstrKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
   parent: keyVault
-  name: 'azure_monitor_instrumentation_key'
+  name: 'azure-monitor-instrumentation-key'
 }
 
 resource appInsightsConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
   parent: keyVault
-  name: 'azure_connection_string'
+  name: 'azure-connection-string'
 }
 
 // Grant all services access to App Insights secrets for telemetry

--- a/infra/azure/modules/keyvault-rbac.bicep
+++ b/infra/azure/modules/keyvault-rbac.bicep
@@ -66,12 +66,12 @@ resource authJwtPublicKeyAccess 'Microsoft.Authorization/roleAssignments@2022-04
 
 resource appInsightsInstrKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
   parent: keyVault
-  name: 'appinsights-instrumentation-key'
+  name: 'azure_monitor_instrumentation_key'
 }
 
 resource appInsightsConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
   parent: keyVault
-  name: 'appinsights-connection-string'
+  name: 'azure_connection_string'
 }
 
 // Grant all services access to App Insights secrets for telemetry

--- a/ingestion/main.py
+++ b/ingestion/main.py
@@ -212,15 +212,7 @@ def main():
                 )
             else:
                 metrics = create_metrics_collector(driver_name="noop")
-        except Exception as e:  # graceful fallback for missing optional deps
-            from copilot_metrics import NoOpMetricsCollector
 
-            service_logger.warning(
-                "Metrics backend unavailable; falling back to NoOp",
-                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
-                error=str(e),
-            )
-            metrics = NoOpMetricsCollector()
 
         log = service_logger
 

--- a/ingestion/main.py
+++ b/ingestion/main.py
@@ -194,8 +194,7 @@ def main():
         from app import service as ingestion_service_module
         ingestion_service_module.logger = get_logger(ingestion_service_module.__name__)
 
-        # Build metrics collector, fall back to NoOp if backend unavailable
-        try:
+        # Create metrics collector - fail fast on errors
             metrics_adapter = config.get_adapter("metrics")
             if metrics_adapter is not None:
                 # Create new DriverConfig with modified config dict

--- a/ingestion/main.py
+++ b/ingestion/main.py
@@ -195,22 +195,22 @@ def main():
         ingestion_service_module.logger = get_logger(ingestion_service_module.__name__)
 
         # Create metrics collector - fail fast on errors
-            metrics_adapter = config.get_adapter("metrics")
-            if metrics_adapter is not None:
-                # Create new DriverConfig with modified config dict
-                metrics_config = dict(metrics_adapter.driver_config.config)
-                metrics_config.setdefault("job", "ingestion")
-                metrics_driver_config = DriverConfig(
-                    driver_name=metrics_adapter.driver_config.driver_name,
-                    config=metrics_config,
-                    allowed_keys=metrics_adapter.driver_config.allowed_keys,
-                )
-                metrics = create_metrics_collector(
-                    driver_name=metrics_adapter.driver_name,
-                    driver_config=metrics_driver_config,
-                )
-            else:
-                metrics = create_metrics_collector(driver_name="noop")
+        metrics_adapter = config.get_adapter("metrics")
+        if metrics_adapter is not None:
+            # Create new DriverConfig with modified config dict
+            metrics_config = dict(metrics_adapter.driver_config.config)
+            metrics_config.setdefault("job", "ingestion")
+            metrics_driver_config = DriverConfig(
+                driver_name=metrics_adapter.driver_config.driver_name,
+                config=metrics_config,
+                allowed_keys=metrics_adapter.driver_config.allowed_keys,
+            )
+            metrics = create_metrics_collector(
+                driver_name=metrics_adapter.driver_name,
+                driver_config=metrics_driver_config,
+            )
+        else:
+            metrics = create_metrics_collector(driver_name="noop")
 
 
         log = service_logger

--- a/ingestion/main.py
+++ b/ingestion/main.py
@@ -217,7 +217,7 @@ def main():
 
             service_logger.warning(
                 "Metrics backend unavailable; falling back to NoOp",
-                backend=config.metrics_type,
+                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
                 error=str(e),
             )
             metrics = NoOpMetricsCollector()

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -193,24 +193,24 @@ def main():
 
         # Create metrics collector - fail fast on errors
         log.info("Creating metrics collector...")
-            metrics_adapter = config.get_adapter("metrics")
-            if metrics_adapter is not None:
-                from copilot_config import DriverConfig
-                metrics_driver_config = DriverConfig(
-                    driver_name=metrics_adapter.driver_name,
-                    config={**metrics_adapter.driver_config.config, "job": "orchestrator"},
-                    allowed_keys=metrics_adapter.driver_config.allowed_keys
-                )
-                metrics_collector = create_metrics_collector(
-                    driver_name=metrics_adapter.driver_name,
-                    driver_config=metrics_driver_config,
-                )
-            else:
-                from copilot_config import DriverConfig
-                metrics_collector = create_metrics_collector(
-                    driver_name="noop",
-                    driver_config=DriverConfig(driver_name="noop")
-                )
+        metrics_adapter = config.get_adapter("metrics")
+        if metrics_adapter is not None:
+            from copilot_config import DriverConfig
+            metrics_driver_config = DriverConfig(
+                driver_name=metrics_adapter.driver_name,
+                config={**metrics_adapter.driver_config.config, "job": "orchestrator"},
+                allowed_keys=metrics_adapter.driver_config.allowed_keys
+            )
+            metrics_collector = create_metrics_collector(
+                driver_name=metrics_adapter.driver_name,
+                driver_config=metrics_driver_config,
+            )
+        else:
+            from copilot_config import DriverConfig
+            metrics_collector = create_metrics_collector(
+                driver_name="noop",
+                driver_config=DriverConfig(driver_name="noop")
+            )
 
 
         # Create error reporter using adapter configuration (optional)

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -193,7 +193,6 @@ def main():
 
         # Create metrics collector - fail fast on errors
         log.info("Creating metrics collector...")
-        try:
             metrics_adapter = config.get_adapter("metrics")
             if metrics_adapter is not None:
                 from copilot_config import DriverConfig

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -212,18 +212,7 @@ def main():
                     driver_name="noop",
                     driver_config=DriverConfig(driver_name="noop")
                 )
-        except Exception as e:
-            from copilot_config import DriverConfig
 
-            log.warning(
-                "Metrics backend unavailable; falling back to NoOp",
-                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
-                error=str(e),
-            )
-            metrics_collector = create_metrics_collector(
-                driver_name="noop",
-                driver_config=DriverConfig(driver_name="noop")
-            )
 
         # Create error reporter using adapter configuration (optional)
         log.info("Creating error reporter...")

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -217,7 +217,7 @@ def main():
 
             log.warning(
                 "Metrics backend unavailable; falling back to NoOp",
-                backend=config.metrics_type,
+                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
                 error=str(e),
             )
             metrics_collector = create_metrics_collector(

--- a/parsing/main.py
+++ b/parsing/main.py
@@ -241,10 +241,9 @@ def main():
                 )
         except Exception as e:
             from copilot_config import DriverConfig
-            from copilot_config import DriverConfig
             log.warning(
                 "Metrics backend unavailable; falling back to NoOp",
-                backend=config.metrics_type,
+                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
                 error=str(e),
             )
             metrics_collector = create_metrics_collector(

--- a/parsing/main.py
+++ b/parsing/main.py
@@ -220,32 +220,21 @@ def main():
 
         # Create metrics collector - fail fast on errors
         log.info("Creating metrics collector...")
-        try:
-            metrics_adapter = config.get_adapter("metrics")
-            if metrics_adapter is not None:
-                from copilot_config import DriverConfig
-                metrics_driver_config = DriverConfig(
-                    driver_name=metrics_adapter.driver_name,
-                    config={**metrics_adapter.driver_config.config, "job": "parsing"},
-                    allowed_keys=metrics_adapter.driver_config.allowed_keys
-                )
-                metrics_collector = create_metrics_collector(
-                    driver_name=metrics_adapter.driver_name,
-                    driver_config=metrics_driver_config,
-                )
-            else:
-                from copilot_config import DriverConfig
-                metrics_collector = create_metrics_collector(
-                    driver_name="noop",
-                    driver_config=DriverConfig(driver_name="noop")
-                )
-        except Exception as e:
-            from copilot_config import DriverConfig
-            log.warning(
-                "Metrics backend unavailable; falling back to NoOp",
-                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
-                error=str(e),
+        from copilot_config import DriverConfig
+        metrics_adapter = config.get_adapter("metrics")
+        if metrics_adapter is not None:
+            # Metrics adapter is configured - initialization MUST succeed
+            metrics_driver_config = DriverConfig(
+                driver_name=metrics_adapter.driver_name,
+                config={**metrics_adapter.driver_config.config, "job": "parsing"},
+                allowed_keys=metrics_adapter.driver_config.allowed_keys
             )
+            metrics_collector = create_metrics_collector(
+                driver_name=metrics_adapter.driver_name,
+                driver_config=metrics_driver_config,
+            )
+        else:
+            # No metrics adapter configured - use noop
             metrics_collector = create_metrics_collector(
                 driver_name="noop",
                 driver_config=DriverConfig(driver_name="noop")

--- a/reporting/main.py
+++ b/reporting/main.py
@@ -522,10 +522,9 @@ def main():
                 )
         except Exception as e:
             from copilot_config import DriverConfig
-            from copilot_config import DriverConfig
             logger.warning(
                 "Metrics backend unavailable; falling back to NoOp",
-                backend=config.metrics_type,
+                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
             )
             metrics_collector = create_metrics_collector(
                 driver_name="noop",

--- a/reporting/main.py
+++ b/reporting/main.py
@@ -501,7 +501,6 @@ def main():
 
         # Create metrics collector - fail fast on errors
         logger.info("Creating metrics collector...")
-        try:
             metrics_adapter = config.get_adapter("metrics")
             if metrics_adapter is not None:
                 from copilot_config import DriverConfig

--- a/reporting/main.py
+++ b/reporting/main.py
@@ -520,16 +520,6 @@ def main():
                     driver_name="noop",
                     driver_config=DriverConfig(driver_name="noop")
                 )
-        except Exception as e:
-            from copilot_config import DriverConfig
-            logger.warning(
-                "Metrics backend unavailable; falling back to NoOp",
-                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
-            )
-            metrics_collector = create_metrics_collector(
-                driver_name="noop",
-                driver_config=DriverConfig(driver_name="noop")
-            )
 
         # Create error reporter - fail fast on errors
         logger.info("Creating error reporter...")

--- a/reporting/main.py
+++ b/reporting/main.py
@@ -501,24 +501,24 @@ def main():
 
         # Create metrics collector - fail fast on errors
         logger.info("Creating metrics collector...")
-            metrics_adapter = config.get_adapter("metrics")
-            if metrics_adapter is not None:
-                from copilot_config import DriverConfig
-                metrics_driver_config = DriverConfig(
-                    driver_name=metrics_adapter.driver_name,
-                    config={**metrics_adapter.driver_config.config, "job": "reporting"},
-                    allowed_keys=metrics_adapter.driver_config.allowed_keys
-                )
-                metrics_collector = create_metrics_collector(
-                    driver_name=metrics_adapter.driver_name,
-                    driver_config=metrics_driver_config,
-                )
-            else:
-                from copilot_config import DriverConfig
-                metrics_collector = create_metrics_collector(
-                    driver_name="noop",
-                    driver_config=DriverConfig(driver_name="noop")
-                )
+        metrics_adapter = config.get_adapter("metrics")
+        if metrics_adapter is not None:
+            from copilot_config import DriverConfig
+            metrics_driver_config = DriverConfig(
+                driver_name=metrics_adapter.driver_name,
+                config={**metrics_adapter.driver_config.config, "job": "reporting"},
+                allowed_keys=metrics_adapter.driver_config.allowed_keys
+            )
+            metrics_collector = create_metrics_collector(
+                driver_name=metrics_adapter.driver_name,
+                driver_config=metrics_driver_config,
+            )
+        else:
+            from copilot_config import DriverConfig
+            metrics_collector = create_metrics_collector(
+                driver_name="noop",
+                driver_config=DriverConfig(driver_name="noop")
+            )
 
         # Create error reporter - fail fast on errors
         logger.info("Creating error reporter...")

--- a/scripts/validate_bicep_config.py
+++ b/scripts/validate_bicep_config.py
@@ -250,6 +250,17 @@ def validate_config(env_vars: dict, schema: dict, service_name: str) -> list:
             if selected_driver is None:
                 # Conditional or computed; skip deep validation for this adapter
                 continue
+            
+            # Check if value contains ternary operator (Bicep conditional expression)
+            # These can't be evaluated at validation time, so skip deep validation
+            if '?' in str(selected_driver):
+                # Still validate it's a valid Bicep ternary pattern (has ? and :)
+                if ':' not in str(selected_driver):
+                    issues.append(
+                        f"Invalid ternary expression for {discriminant_env_var}: missing ':' (adapter '{adapter_name}')"
+                    )
+                # Skip deep validation since we can't determine which driver will be selected at runtime
+                continue
 
             if enum_values and selected_driver not in enum_values:
                 issues.append(

--- a/summarization/main.py
+++ b/summarization/main.py
@@ -222,7 +222,6 @@ def main():
         )
 
         log.info("Creating metrics collector...")
-        try:
             metrics_adapter = config.get_adapter("metrics")
             if metrics_adapter is not None:
                 from copilot_config import DriverConfig

--- a/summarization/main.py
+++ b/summarization/main.py
@@ -241,18 +241,6 @@ def main():
                     driver_name="noop",
                     driver_config=DriverConfig(driver_name="noop")
                 )
-        except Exception as e:
-            from copilot_config import DriverConfig
-            log.warning(
-                "Metrics backend unavailable; falling back to NoOp",
-                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
-                error=str(e),
-            )
-            metrics_collector = create_metrics_collector(
-                driver_name="noop",
-                driver_config=DriverConfig(driver_name="noop")
-            )
-            metrics_collector = NoOpMetricsCollector()
 
         log.info("Creating error reporter...")
         error_reporter_adapter = config.get_adapter("error_reporter")

--- a/summarization/main.py
+++ b/summarization/main.py
@@ -222,24 +222,24 @@ def main():
         )
 
         log.info("Creating metrics collector...")
-            metrics_adapter = config.get_adapter("metrics")
-            if metrics_adapter is not None:
-                from copilot_config import DriverConfig
-                metrics_driver_config = DriverConfig(
-                    driver_name=metrics_adapter.driver_name,
-                    config={**metrics_adapter.driver_config.config, "job": "summarization"},
-                    allowed_keys=metrics_adapter.driver_config.allowed_keys
-                )
-                metrics_collector = create_metrics_collector(
-                    driver_name=metrics_adapter.driver_name,
-                    driver_config=metrics_driver_config,
-                )
-            else:
-                from copilot_config import DriverConfig
-                metrics_collector = create_metrics_collector(
-                    driver_name="noop",
-                    driver_config=DriverConfig(driver_name="noop")
-                )
+        metrics_adapter = config.get_adapter("metrics")
+        if metrics_adapter is not None:
+            from copilot_config import DriverConfig
+            metrics_driver_config = DriverConfig(
+                driver_name=metrics_adapter.driver_name,
+                config={**metrics_adapter.driver_config.config, "job": "summarization"},
+                allowed_keys=metrics_adapter.driver_config.allowed_keys
+            )
+            metrics_collector = create_metrics_collector(
+                driver_name=metrics_adapter.driver_name,
+                driver_config=metrics_driver_config,
+            )
+        else:
+            from copilot_config import DriverConfig
+            metrics_collector = create_metrics_collector(
+                driver_name="noop",
+                driver_config=DriverConfig(driver_name="noop")
+            )
 
         log.info("Creating error reporter...")
         error_reporter_adapter = config.get_adapter("error_reporter")

--- a/summarization/main.py
+++ b/summarization/main.py
@@ -245,7 +245,7 @@ def main():
             from copilot_config import DriverConfig
             log.warning(
                 "Metrics backend unavailable; falling back to NoOp",
-                backend=config.metrics_type,
+                backend=metrics_adapter.driver_name if metrics_adapter else "noop",
                 error=str(e),
             )
             metrics_collector = create_metrics_collector(


### PR DESCRIPTION
## Summary

Architectural fix: Secrets should be loaded via `secret_provider` from Key Vault using schema `secret_name` field, not injected as environment variables with `@Microsoft.KeyVault(...)` references.

## Problem

The Bicep deployment was incorrectly passing secrets as environment variables with Key Vault references, bypassing the secret provider architecture where secrets should only exist in Key Vault and be loaded transparently using schema metadata.

## Changes

### Infrastructure (containerapps.bicep)
- **Removed** `APPINSIGHTS_INSTRUMENTATIONKEY` from 8 services (auth, reporting, ingestion, parsing, chunking, embedding, orchestrator, summarization)
- **Removed** `APPLICATIONINSIGHTS_CONNECTION_STRING` from 8 services
- **Removed** `AZURE_OPENAI_API_KEY` from 4 services (reporting, embedding, orchestrator, summarization)

These secrets are already in Key Vault with correct names:
- `azure_monitor_instrumentation_key`
- `azure_connection_string`
- `azure_openai_api_key`

They will be loaded automatically by `copilot_config` Phase 3 using the secret_provider with managed identity.

### Validator Enhancement (scripts/validate_bicep_config.py)
- **Added** `_extract_keyvault_references_from_env()` to detect `@Microsoft.KeyVault(...)` patterns in env vars
- **Updated** `extract_env_vars()` regex to capture multi-line values (DOTALL flag)
- **Enhanced** validation to flag env vars with Key Vault references as architectural violations
- **Added** ternary expression handling to skip deep validation for Bicep conditional expressions that can't be evaluated at validation time

### Azure Monitor Metrics Configuration Fixes

#### 1. Key Vault Secret Name Validation (Commit: 5a3ebe4f)
**Issue**: Tried to create Key Vault secrets with underscores, but Azure Key Vault only accepts alphanumeric characters and hyphens.
**Fix**: Updated secret names in Bicep templates to use hyphens:
- `main.bicep`: `azure_monitor_instrumentation_key` → `azure-monitor-instrumentation-key`
- `main.bicep`: `azure_connection_string` → `azure-connection-string`
- `keyvault-rbac.bicep`: Updated secret references
- The `AzureKeyVaultProvider` has built-in `_normalize_secret_name()` that transparently converts underscores to hyphens
- Schema files correctly use underscores for filesystem compatibility with local secrets

#### 2. Service Error Handling (Commit: 0356b995)
**Issue**: Service exception handlers tried to access `config.metrics_type` which doesn't exist, masking the real error
**Fix**: Changed to use `metrics_adapter.driver_name` if available

#### 3. Fail-Fast Metrics Initialization (Commit: 76280111)
**Issue**: Services silently fell back to noop metrics, masking configuration errors
**Fix**: Removed try-except blocks that swallowed metrics initialization errors
- If metrics adapter is configured, initialization MUST succeed
- Services fail immediately with clear error messages
- Diagnostic visibility for Azure Monitor auth, secret loading, and connectivity issues

#### 4. Error Logging Improvements (Commit: a13778d8)
**Issue**: Secret provider initialization failures were silently caught
**Fix**: Added logging:
- Phase 2 (secret_provider init): Logs WARNING if initialization fails
- Driver config loading: Logs DEBUG when individual secrets fail to load

### Secret Loading Flow (with improvements)
1. **Phase 1**: Load adapter configs (discriminants only)
   - Discovers `SECRET_PROVIDER_TYPE=azure_key_vault` and `AZURE_KEY_VAULT_NAME=...`
   
2. **Phase 2**: Create Azure Key Vault provider using DefaultAzureCredential (managed identity)
   - **NOW LOGS**: WARNING if initialization fails (was silent before)
   
3. **Phase 3**: Load full config with secrets resolved
   - For metrics driver: Uses secret_provider to load `azure_monitor_instrumentation_key` and `azure_connection_string`
   - **NOW LOGS**: DEBUG when individual secrets fail to load (was silent before)

## Validation Results

✅ **ALL 8 microservices PASSED validation:**
- auth, reporting, ingestion, parsing, chunking, embedding, orchestrator, summarization

⏭️ **2 frontend services skipped:** ui, gateway

## Architecture Compliance

✅ Zero architectural violations  
✅ Zero secrets in environment variables  
✅ All secrets loaded via secret_provider with managed identity  
✅ Validator catches architectural antipatterns before deployment  
✅ Azure Monitor metrics properly configured with Key Vault secret loading
✅ Fail-fast error detection for misconfigured metrics

## Impact

- Services will load secrets from Key Vault automatically via managed identity
- No secrets exposed in environment variables or deployment configuration
- Validator prevents regression of this antipattern
- Azure Monitor metrics configuration is explicit and fails immediately if misconfigured
- Full diagnostic visibility into secret loading and authentication errors
- Improved security posture and compliance with secret management best practices

## Related Issues

Closes #854

## Testing

```bash
# Run validator on all services
python scripts/validate_bicep_all_services.py infra/azure/modules/containerapps.bicep

# Result: 8 passed, 0 failed, 2 skipped
```

Container images need to be built via GitHub Actions before deployment to test these changes.