### PR TITLE
Add rsync to azure ingestion image

### DIFF
--- a/ingestion/Dockerfile.azure
+++ b/ingestion/Dockerfile.azure
@@ -5,6 +5,11 @@
 # Uses Azure Blob Storage instead of local filesystem
 FROM python:3.14-slim@sha256:1f741aef81d09464251f4c52c83a02f93ece0a636db125d411bd827bf381a763
 
+# Install rsync for archive fetching
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends rsync && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Install shared adapters in dependency order using centralized script


### PR DESCRIPTION
This pull request makes a minor update to the `ingestion/Dockerfile.azure` to support archive fetching. The change adds the installation of `rsync` to the image, which will be used for this purpose.

* Docker image improvement:
  * Installed `rsync` via `apt-get` to enable archive fetching in the Azure ingestion Docker image.