### PR TITLE
Disable request buffering

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -154,6 +154,10 @@ http {
     # Web UI (served from subpath)
     location /ui/ {
       proxy_http_version 1.1;
+      # Stream UI responses directly to clients (avoid temp-file buffering).
+      # This prevents partial/truncated asset responses observed behind some proxies.
+      proxy_buffering off;
+      proxy_request_buffering off;
       proxy_set_header Host $proxy_host;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -284,6 +288,10 @@ http {
 #    # Web UI (served from subpath)
 #    location /ui/ {
 #      proxy_http_version 1.1;
+#      # Stream UI responses directly to clients (avoid temp-file buffering).
+#      # This prevents partial/truncated asset responses observed behind some proxies.
+#      proxy_buffering off;
+#      proxy_request_buffering off;
 #      proxy_set_header Host $proxy_host;
 #      proxy_set_header X-Real-IP $remote_addr;
 #      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This pull request updates the Nginx configuration to improve how UI responses are proxied. The main change is disabling response and request buffering for the `/ui/` location, which helps prevent issues with partial or truncated asset responses, especially when Nginx is used behind certain proxies.

**Nginx proxy configuration improvements:**

* Disabled `proxy_buffering` and `proxy_request_buffering` for the `/ui/` location in the active configuration to ensure UI responses are streamed directly to clients, reducing the risk of partial or truncated responses.
* Made the same buffering configuration changes in the commented-out example block for `/ui/` to keep documentation and examples consistent.