### PR TITLE
Bump prometheus-client from 0.23.1 to 0.24.1

### DIFF
--- a/auth/requirements.in
+++ b/auth/requirements.in
@@ -14,7 +14,7 @@ uvicorn[standard]>=0.40.0
 python-multipart>=0.0.20
 
 # Monitoring
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 
 # HTTP client for OIDC
 httpx>=0.28.1

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -43,7 +43,7 @@ idna==3.11
     #   anyio
     #   httpx
     #   requests
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/chunking/requirements.in
+++ b/chunking/requirements.in
@@ -11,7 +11,7 @@
 python-dotenv>=1.2.1
 fastapi>=0.127.0
 uvicorn>=0.40.0
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/chunking/requirements.txt
+++ b/chunking/requirements.txt
@@ -22,7 +22,7 @@ h11==0.16.0
     # via uvicorn
 idna==3.11
     # via anyio
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/embedding/requirements.in
+++ b/embedding/requirements.in
@@ -11,7 +11,7 @@
 python-dotenv>=1.2.1
 fastapi>=0.127.0
 uvicorn>=0.40.0
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -22,7 +22,7 @@ h11==0.16.0
     # via uvicorn
 idna==3.11
     # via anyio
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/ingestion/requirements.in
+++ b/ingestion/requirements.in
@@ -9,7 +9,7 @@
 # via scripts/install_adapters.py and are not included in this lockfile.
 
 python-dotenv>=1.2.1
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 fastapi>=0.127.0
 uvicorn[standard]>=0.40.0
 httpx>=0.28.1  # Required for FastAPI TestClient

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -39,7 +39,7 @@ idna==3.11
     # via
     #   anyio
     #   httpx
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/orchestrator/requirements.in
+++ b/orchestrator/requirements.in
@@ -13,7 +13,7 @@ uvicorn>=0.40.0
 httpx>=0.28.1  # Required for FastAPI TestClient
 python-dotenv>=1.2.1
 # Monitoring
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -36,7 +36,7 @@ idna==3.11
     # via
     #   anyio
     #   httpx
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/parsing/requirements.in
+++ b/parsing/requirements.in
@@ -11,7 +11,7 @@
 beautifulsoup4>=4.14.3
 fastapi>=0.127.0
 uvicorn>=0.40.0
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/parsing/requirements.txt
+++ b/parsing/requirements.txt
@@ -24,7 +24,7 @@ h11==0.16.0
     # via uvicorn
 idna==3.11
     # via anyio
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/reporting/requirements.in
+++ b/reporting/requirements.in
@@ -13,7 +13,7 @@ fastapi>=0.127.0
 uvicorn>=0.40.0
 requests>=2.32.5
 httpx>=0.28.1
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -40,7 +40,7 @@ idna==3.11
     #   anyio
     #   httpx
     #   requests
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi

--- a/summarization/requirements.in
+++ b/summarization/requirements.in
@@ -11,7 +11,7 @@
 python-dotenv>=1.2.1
 fastapi>=0.127.0
 uvicorn>=0.40.0
-prometheus-client>=0.23.1
+prometheus-client>=0.24.1
 # Authentication
 PyJWT>=2.10.1
 cryptography>=46.0.3

--- a/summarization/requirements.txt
+++ b/summarization/requirements.txt
@@ -22,7 +22,7 @@ h11==0.16.0
     # via uvicorn
 idna==3.11
     # via anyio
-prometheus-client==0.23.1
+prometheus-client==0.24.1
     # via -r requirements.in
 pycparser==2.23
     # via cffi


### PR DESCRIPTION
Bumps prometheus-client from 0.23.1 to 0.24.1.

- License header check: not run in this PR (dependency bump only)