### PR TITLE
Fix ACA UI asset truncation via gzip + buffered proxying

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -55,6 +55,8 @@ http {
     # Avoid adding internal port 8080/8443 to redirects
     port_in_redirect off;
 
+    add_header X-CFC-Gateway 1 always;
+
     # Health endpoint for container healthcheck
     location = /health {
       add_header Content-Type text/plain;
@@ -154,10 +156,8 @@ http {
     # Web UI (served from subpath)
     location /ui/ {
       proxy_http_version 1.1;
-      # Stream UI responses directly to clients (avoid temp-file buffering).
-      # This prevents partial/truncated asset responses observed behind some proxies.
-      proxy_buffering off;
-      proxy_request_buffering off;
+      # Buffer UI responses to improve compatibility with Azure Container Apps ingress (Envoy)
+      # and avoid client-visible truncation for larger static assets.
       proxy_set_header Host $proxy_host;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -288,10 +288,8 @@ http {
 #    # Web UI (served from subpath)
 #    location /ui/ {
 #      proxy_http_version 1.1;
-#      # Stream UI responses directly to clients (avoid temp-file buffering).
-#      # This prevents partial/truncated asset responses observed behind some proxies.
-#      proxy_buffering off;
-#      proxy_request_buffering off;
+#      # Buffer UI responses to improve compatibility with Azure Container Apps ingress (Envoy)
+#      # and avoid client-visible truncation for larger static assets.
 #      proxy_set_header Host $proxy_host;
 #      proxy_set_header X-Real-IP $remote_addr;
 #      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -29,6 +29,8 @@ server {
   server_name _;
   root /usr/share/nginx/html;
 
+  add_header X-CFC-UI 1 always;
+
   # Disable sendfile for Azure Container Apps / Envoy compatibility
   # When running behind Envoy (ACA ingress), sendfile can cause response truncation
   sendfile off;
@@ -37,6 +39,21 @@ server {
 
   # Increase client body size limit for file uploads (100MB)
   client_max_body_size 100M;
+
+  # Reduce transferred bytes for large JS/CSS assets.
+  # This can mitigate intermittent truncation observed behind proxy chains (e.g., ACA ingress).
+  gzip on;
+  gzip_comp_level 6;
+  gzip_min_length 1024;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_types
+    text/plain
+    text/css
+    application/json
+    application/javascript
+    application/xml
+    image/svg+xml;
 
   location / {
     try_files $uri $uri/ /index.html;

--- a/ui/Dockerfile.azure
+++ b/ui/Dockerfile.azure
@@ -33,6 +33,8 @@ server {
   server_name _;
   root /usr/share/nginx/html;
 
+  add_header X-CFC-UI 1 always;
+
   # Disable sendfile for Azure Container Apps / Envoy compatibility
   # When running behind Envoy (ACA ingress), sendfile can cause response truncation
   sendfile off;
@@ -41,6 +43,21 @@ server {
 
   # Increase client body size limit for file uploads (100MB)
   client_max_body_size 100M;
+
+  # Reduce transferred bytes for large JS/CSS assets.
+  # This can mitigate intermittent truncation observed behind proxy chains (e.g., ACA ingress).
+  gzip on;
+  gzip_comp_level 6;
+  gzip_min_length 1024;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_types
+    text/plain
+    text/css
+    application/json
+    application/javascript
+    application/xml
+    image/svg+xml;
 
   location / {
     try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Problem
In Azure Container Apps (ACA) behind the gateway, large UI assets (e.g., `/ui/assets/index-*.js`) intermittently truncated during GET, surfacing as `curl: (18) end of response with ... bytes missing`. Local Docker Compose did not reproduce.

## What changed
- Enable gzip for UI static assets so responses are compressed and delivered as `Transfer-Encoding: chunked` for these requests, reducing bytes transferred and avoiding client-visible truncation.
- Keep gateway `/ui/` proxying buffered (avoid forced streaming).
- Add trace headers for troubleshooting:
  - `X-CFC-UI: 1` from the UI container
  - `X-CFC-Gateway: 1` from the gateway

## Files
- UI gzip + trace header: `ui/Dockerfile`, `ui/Dockerfile.azure`
- Gateway trace header + buffered proxying: `infra/nginx/nginx.conf`
- Updated troubleshooting guidance: `docs/operations/azure-nginx-sendfile-fix.md`

## How to test
```powershell
# Replace with the current hashed asset in your environment
$url = "https://dev.copilot-for-consensus.com/ui/assets/index-<hash>.js"

# Expect: content-encoding: gzip, transfer-encoding: chunked, x-cfc-ui: 1, x-cfc-gateway: 1
curl.exe -sS -I -H "Accept-Encoding: gzip" $url

# Must complete without curl 18
curl.exe -sS --compressed -o $env:TEMP\ui-asset.js $url
```

## Notes
This complements the existing ACA/Envoy guidance to disable `sendfile` and avoid unbuffered streaming for large assets.