### PR TITLE
azure: default deploy scripts to azure image tag

### DIFF
--- a/infra/azure/IMPLEMENTATION_SUMMARY.md
+++ b/infra/azure/IMPLEMENTATION_SUMMARY.md
@@ -127,7 +127,7 @@ The ARM template deploys:
 
 ✅ **Each service is deployed using its container image from ghcr.io**
 - Images referenced as `ghcr.io/alan-jowett/copilot-for-consensus/<service>:<tag>`
-- Tag is parameterized (default: latest)
+- Tag is parameterized (default: azure)
 
 ## Deployment Modes
 

--- a/infra/azure/deploy.env.ps1
+++ b/infra/azure/deploy.env.ps1
@@ -12,7 +12,7 @@ param(
     [string]$ParametersFile = "",
     [string]$ProjectName = "copilot",
     [string]$Environment = "dev",
-    [string]$ImageTag = "latest",
+    [string]$ImageTag = "azure",
     [switch]$ValidateOnly,
     [switch]$Help
 )
@@ -45,7 +45,7 @@ OPTIONS:
     -ParametersFile     Path to parameters file (default: parameters.<env>.json)
     -ProjectName        Project name prefix (default: copilot)
     -Environment        Environment (dev/staging/prod, default: dev)
-    -ImageTag           Container image tag (default: latest)
+    -ImageTag           Container image tag (default: azure)
     -ValidateOnly       Validate template without deploying
     -Help               Display this help message
 

--- a/infra/azure/deploy.env.sh
+++ b/infra/azure/deploy.env.sh
@@ -59,7 +59,7 @@ OPTIONS:
     -p, --parameters        Path to parameters file (default: parameters.<env>.json)
     -n, --project-name      Project name prefix (default: copilot)
     -e, --environment       Environment (dev/staging/prod, default: dev)
-    -t, --image-tag         Container image tag (default: latest)
+    -t, --image-tag         Container image tag (default: azure)
     -v, --validate-only     Validate template without deploying
     -h, --help              Display this help message
 
@@ -91,7 +91,7 @@ LOCATION="westus"
 PARAMETERS_FILE=""
 PROJECT_NAME="copilot"
 ENVIRONMENT="dev"
-IMAGE_TAG="latest"
+IMAGE_TAG="azure"
 VALIDATE_ONLY=false
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/infra/azure/deploy.ps1
+++ b/infra/azure/deploy.ps1
@@ -25,7 +25,7 @@
     Environment name: dev, staging, or prod (default: dev).
 
 .PARAMETER ImageTag
-    Container image tag to deploy (default: latest).
+    Container image tag to deploy (default: azure).
 
 .PARAMETER ValidateOnly
     Only validate the template without deploying.
@@ -59,7 +59,7 @@ param(
     [string]$Environment = "dev",
 
     [Parameter(Mandatory=$false)]
-    [string]$ImageTag = "latest",
+    [string]$ImageTag = "azure",
 
     [Parameter(Mandatory=$false)]
     [switch]$ValidateOnly

--- a/infra/azure/deploy.sh
+++ b/infra/azure/deploy.sh
@@ -58,7 +58,7 @@ OPTIONS:
     -p, --parameters        Path to parameters file (default: parameters.dev.json)
     -n, --project-name      Project name prefix (default: copilot)
     -e, --environment       Environment (dev/staging/prod, default: dev)
-    -t, --image-tag         Container image tag (default: latest)
+    -t, --image-tag         Container image tag (default: azure)
     -v, --validate-only     Validate template without deploying
     -h, --help              Display this help message
 
@@ -81,7 +81,7 @@ LOCATION="eastus"
 PARAMETERS_FILE="parameters.dev.json"
 PROJECT_NAME="copilot"
 ENVIRONMENT="dev"
-IMAGE_TAG="latest"
+IMAGE_TAG="azure"
 VALIDATE_ONLY=false
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
## What
- Changes Azure deployment helper scripts to default the container image tag to `azure` instead of `latest`.

## Why
- The Azure-optimized images are the intended default for Azure deployments; `latest` remains available via `--image-tag/-ImageTag` overrides.

## Changes
- Update defaults + usage text in:
  - `infra/azure/deploy.sh`
  - `infra/azure/deploy.env.sh`
  - `infra/azure/deploy.ps1`
  - `infra/azure/deploy.env.ps1`
- Align `infra/azure/IMPLEMENTATION_SUMMARY.md` to match the new default.

## Notes
- No behavior change when users explicitly pass `--image-tag latest` / `-ImageTag latest`.