### PR TITLE
CI: run schema-validation when typed-config generator changes

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -9,12 +9,16 @@ on:
     paths:
       - 'docs/schemas/configs/**'
       - 'adapters/copilot_config/**'
+      - 'adapters/copilot_config/copilot_config/generated/**'
+      - 'scripts/generate_typed_configs.py'
       - '.github/workflows/schema-validation.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/schemas/configs/**'
       - 'adapters/copilot_config/**'
+      - 'adapters/copilot_config/copilot_config/generated/**'
+      - 'scripts/generate_typed_configs.py'
       - '.github/workflows/schema-validation.yml'
   workflow_dispatch:  # Allow manual triggering
 


### PR DESCRIPTION
Updates Schema Validation workflow triggers so the typed-config generation drift check runs when:
- `scripts/generate_typed_configs.py` changes (previously missed due to path filters)
- generated typed config outputs change (explicit path, for clarity)

Tracks #961.