### PR TITLE
Mitigate reporting truncation via gzip

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -22,6 +22,22 @@ http {
   include       mime.types;
   default_type  application/octet-stream;
 
+  # Response compression
+  # Reduce bytes-on-the-wire for large JSON responses (e.g., /reporting/api/reports)
+  # as a workaround for intermittent truncation/reset behavior behind proxies.
+  gzip on;
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_min_length 1024;
+  gzip_comp_level 5;
+  gzip_types
+    application/json
+    text/plain
+    text/css
+    application/javascript
+    application/xml
+    text/xml;
+
   # Disable sendfile for Azure Container Apps / Envoy compatibility
   # When running behind Envoy (ACA ingress), sendfile can cause response truncation
   # because the proxy may not correctly handle file descriptor passing
@@ -30,23 +46,57 @@ http {
   tcp_nodelay     on;
   keepalive_timeout  65;
 
-  # Proxy buffering settings to prevent truncation issues
-  proxy_buffering on;
-  proxy_buffer_size 4k;
-  proxy_buffers 8 4k;
-  proxy_busy_buffers_size 8k;
+  # Disable disk-spillover for MB-sized files
+  proxy_max_temp_file_size 0; 
 
-  # Basic logging
-  access_log  /var/log/nginx/access.log;
-  error_log   /var/log/nginx/error.log warn;
+  # Increase memory buffers to handle larger headers/initial chunks
+  proxy_buffer_size 128k;
+  proxy_buffers 4 256k;
+  proxy_busy_buffers_size 256k;
+  
+  # Request correlation
+  # Prefer an incoming X-Request-ID, otherwise synthesize one.
+  # Note: using only core variables to avoid relying on optional NGINX modules.
+  map $http_x_request_id $cfc_request_id {
+    default $http_x_request_id;
+    "" "$msec-$connection-$connection_requests";
+  }
 
   # JWT Authentication for Grafana SSO
-  # Map directive to extract JWT from cookie when Authorization header is absent
-  # More efficient and predictable than using if directives
+  # Derive a Bearer token from the auth cookie *only when it exists*.
+  map $cookie_auth_token $cookie_bearer_auth {
+    "" "";
+    default "Bearer $cookie_auth_token";
+  }
+
+  # If the client didn't provide an Authorization header, fall back to the cookie token.
   map $http_authorization $auth_header {
-    "" "Bearer $cookie_auth_token";
+    "" $cookie_bearer_auth;
     default $http_authorization;
   }
+
+  # Basic logging (JSON) to support root-causing upstream resets.
+  log_format cfc_json escape=json
+    '{'
+    '"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"host":"$host",'
+    '"request":"$request",'
+    '"status":$status,'
+    '"request_time":$request_time,'
+    '"upstream_addr":"$upstream_addr",'
+    '"upstream_status":"$upstream_status",'
+    '"upstream_connect_time":"$upstream_connect_time",'
+    '"upstream_header_time":"$upstream_header_time",'
+    '"upstream_response_time":"$upstream_response_time",'
+    '"request_id":"$cfc_request_id",'
+    '"referrer":"$http_referer",'
+    '"user_agent":"$http_user_agent"'
+    '}';
+
+  # Log to stdout/stderr so Azure Container Apps captures logs.
+  access_log  /dev/stdout cfc_json;
+  error_log   /dev/stderr warn;
 
   # HTTP server (always enabled)
   server {
@@ -76,9 +126,18 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Request-ID $cfc_request_id;
+      add_header X-Request-ID $cfc_request_id always;
       # Extract JWT from cookie and add as Authorization header for backend service
       # This allows UI to use cookie-based auth while backend services use Bearer tokens
       proxy_set_header Authorization $auth_header;
+
+      # Make upstream timeouts explicit so we can distinguish slow upstreams from resets.
+      proxy_connect_timeout 10s;
+      proxy_send_timeout 60s;
+      proxy_read_timeout 300s;
+      send_timeout 300s;
+
       proxy_pass ${REPORTING_BACKEND}/;
       proxy_redirect off;
     }
@@ -223,6 +282,16 @@ http {
 #      proxy_set_header X-Real-IP $remote_addr;
 #      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 #      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Request-ID $cfc_request_id;
+#      add_header X-Request-ID $cfc_request_id always;
+#      # Extract JWT from cookie and add as Authorization header for backend service
+#      # This allows UI to use cookie-based auth while backend services use Bearer tokens
+#      proxy_set_header Authorization $auth_header;
+#
+#      proxy_connect_timeout 10s;
+#      proxy_send_timeout 60s;
+#      proxy_read_timeout 300s;
+#      send_timeout 300s;
 #      proxy_pass ${REPORTING_BACKEND}/;
 #      proxy_redirect off;
 #    }

--- a/reporting/main.py
+++ b/reporting/main.py
@@ -41,7 +41,9 @@ from copilot_metrics import create_metrics_collector
 from copilot_error_reporting import create_error_reporter
 from copilot_schema_validation import create_schema_provider
 from copilot_storage import DocumentStoreConnectionError, create_document_store
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import JSONResponse
 
 # Bootstrap logger before configuration is loaded
 bootstrap_logger = create_stdout_logger(level="INFO", name="reporting")
@@ -53,6 +55,11 @@ logger = bootstrap_logger
 
 # Create FastAPI app
 app = FastAPI(title="Reporting Service", version=__version__)
+
+# Compress larger responses (e.g., /api/reports) to reduce bytes-on-the-wire.
+# This is a pragmatic workaround for intermittent truncation/reset issues behind
+# proxies (e.g., Azure Container Apps ingress) when transferring larger JSON.
+app.add_middleware(GZipMiddleware, minimum_size=1024)
 
 # Global service instance
 reporting_service = None
@@ -99,6 +106,7 @@ def get_stats():
 
 @app.get("/api/reports")
 def get_reports(
+    request: Request,
     thread_id: str = Query(None, description="Filter by thread ID"),
     limit: int = Query(10, ge=1, le=100, description="Maximum number of results"),
     skip: int = Query(0, ge=0, description="Number of results to skip"),
@@ -134,12 +142,21 @@ def get_reports(
             sort_order=sort_order,
         )
 
-        return {
+        payload = {
             "reports": reports,
             "count": len(reports),
             "limit": limit,
             "skip": skip,
         }
+
+        response = JSONResponse(content=payload)
+
+        # Echo request correlation ID when present.
+        request_id = request.headers.get("x-request-id")
+        if request_id:
+            response.headers["X-Request-ID"] = request_id
+
+        return response
 
     except Exception as e:
         logger.error(f"Error fetching reports: {e}", exc_info=True)

--- a/reporting/tests/test_api.py
+++ b/reporting/tests/test_api.py
@@ -135,6 +135,7 @@ def test_get_reports_endpoint(client, test_service, mock_document_store):
     assert data["reports"][0]["summary_id"] == "rpt1"
 
 
+
 @pytest.mark.integration
 def test_get_reports_with_thread_filter(client, test_service, mock_document_store):
     """Test the GET /api/reports endpoint with thread_id filter."""


### PR DESCRIPTION
This pull request introduces several improvements to both the NGINX configuration and the FastAPI reporting service to address issues with large JSON responses, enhance request correlation, and improve logging and proxy handling. The main focus is on mitigating response truncation/reset problems behind proxies (such as Azure Container Apps ingress) and providing better traceability and diagnostics.

**NGINX configuration improvements:**

* Enabled gzip compression for large responses and tuned compression settings to reduce bandwidth usage and mitigate truncation issues behind proxies.
* Increased proxy buffer sizes and disabled disk spillover for large files to improve handling of large headers and initial chunks, reducing the risk of response truncation.
* Implemented request correlation by mapping incoming `X-Request-ID` headers (or synthesizing one if absent) and propagating it to upstream services and response headers. [[1]](diffhunk://#diff-5612d530e1dcfe284e46aacc7bb0aca73b25ba1b5f8efbb0af84601ce789df42L33-R100) [[2]](diffhunk://#diff-5612d530e1dcfe284e46aacc7bb0aca73b25ba1b5f8efbb0af84601ce789df42R129-R140)
* Switched logging to JSON format and redirected logs to stdout/stderr for better integration with Azure Container Apps logging, aiding root-cause analysis of upstream resets.
* Made upstream timeout settings explicit to distinguish slow upstreams from connection resets. [[1]](diffhunk://#diff-5612d530e1dcfe284e46aacc7bb0aca73b25ba1b5f8efbb0af84601ce789df42R129-R140) [[2]](diffhunk://#diff-5612d530e1dcfe284e46aacc7bb0aca73b25ba1b5f8efbb0af84601ce789df42R285-R294)

**FastAPI service changes:**

* Added GZip middleware to compress large JSON responses, further reducing bytes-on-the-wire and working around proxy truncation issues. [[1]](diffhunk://#diff-92f1075631f3feed487098bf8faed5ad26f9004e93ec7d03469f02a502b5d77bL44-R46) [[2]](diffhunk://#diff-92f1075631f3feed487098bf8faed5ad26f9004e93ec7d03469f02a502b5d77bR59-R63)
* Modified the `/api/reports` endpoint to echo the `X-Request-ID` header in responses for improved traceability and correlation across services. [[1]](diffhunk://#diff-92f1075631f3feed487098bf8faed5ad26f9004e93ec7d03469f02a502b5d77bR109) [[2]](diffhunk://#diff-92f1075631f3feed487098bf8faed5ad26f9004e93ec7d03469f02a502b5d77bL137-R160)

**Testing:**

* Minor formatting update in the test suite to maintain consistency.