### PR TITLE
Fix redirect for grafana

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -99,7 +99,7 @@ services:
       - grafana_admin_password
     entrypoint: ["/bin/sh", "-c"]
     environment:
-      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost/grafana/}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-https://localhost/grafana/}
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
 
       # SSO Rollback: Disable JWT-based authentication for Grafana


### PR DESCRIPTION
This pull request makes a minor update to the Grafana service configuration in `docker-compose.infra.yml`, specifically adjusting the default root URL for Grafana to remove the port number from the URL.