### PR TITLE
gateway: fix /grafana/ redirect loop

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -207,7 +207,10 @@ http {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Prefix /grafana;
 
-      proxy_pass "${GRAFANA_BACKEND}/";
+      # Preserve original request URI (including /grafana/) to avoid redirect loops.
+      # Important: do NOT include a trailing slash here, otherwise NGINX strips
+      # the /grafana/ prefix when proxying.
+      proxy_pass ${GRAFANA_BACKEND};
       proxy_redirect off;
     }
     # __GRAFANA_BLOCK_END__
@@ -350,7 +353,7 @@ http {
 #      proxy_set_header Authorization $auth_header;
 #
 #      # Preserve original request URI (including /grafana/) to avoid redirect loops
-#      proxy_pass ${GRAFANA_BACKEND}/;
+#      proxy_pass ${GRAFANA_BACKEND};
 #      proxy_redirect off;
 #    }
 #


### PR DESCRIPTION
Fixes a regression where the gateway NGINX proxy_pass stripped the /grafana/ prefix (trailing slash), causing Grafana to 301/302 back to /grafana/ and loop.\n\nChange: remove the trailing slash from proxy_pass for the /grafana/ route so the full subpath is preserved.