### PR TITLE
fix(gateway): prevent response truncation with Connection: close

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -165,6 +165,10 @@ http {
     # Reporting API (primary)
     location /reporting/ {
       proxy_http_version 1.1;
+      # Enable buffering and keep-alive for reliable delivery of large responses
+      # when ACA Envoy ingress sends Connection: close
+      proxy_buffering on;
+      proxy_set_header Connection "";
       proxy_set_header Host $proxy_host;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -262,8 +266,12 @@ http {
     # Web UI (served from subpath)
     location /ui/ {
       proxy_http_version 1.1;
-      # Buffer UI responses to improve compatibility with Azure Container Apps ingress (Envoy)
-      # and avoid client-visible truncation for larger static assets.
+      # Enable buffering for UI static assets. Required for reliable delivery when
+      # ACA Envoy ingress sends Connection: close - nginx needs to fully buffer
+      # the upstream response before sending to client.
+      proxy_buffering on;
+      # Use keep-alive to UI backend. Connection: close causes truncation of large files.
+      proxy_set_header Connection "";
       proxy_set_header Host $proxy_host;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
When ACA Envoy sends Connection: close, nginx was forwarding this to backends, causing truncation. Fix: use keep-alive with backends and enable proxy_buffering.