### PR TITLE
fix(infra): remove ingestion from Service Bus receiver services

### DIFF
--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -170,7 +170,6 @@ var serviceBusReceiverServices = [
   'orchestrator'
   'summarization'
   'reporting'
-  'ingestion'
 ]
 
 var uniqueSuffix = uniqueString(resourceGroup().id)


### PR DESCRIPTION
Fixes #1046

The ingestion service only publishes events - it does not subscribe to any. Having it in \serviceBusReceiverServices\ caused an orphaned subscription on the \copilot.events\ topic that accumulated messages with no consumer.

## Changes
- Removed \ingestion\ from \serviceBusReceiverServices\ in \infra/azure/main.bicep\

## Note
The orphaned subscription has already been manually deleted from \copilot-sb-dev-y6f2cptt\.