### PR TITLE
Fix ACA Service Bus scaler schema

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -109,6 +109,10 @@ var uniqueSuffix = uniqueString(resourceGroup().id)
 var projectPrefix = take(replace(projectName, '-', ''), 8)
 var caEnvName = '${projectPrefix}-env-${environment}-${take(uniqueSuffix, 5)}'
 
+// KEDA azure-servicebus scaler expects the Service Bus *namespace name* in rule metadata.
+// Our services use the fully qualified namespace (FQDN) for runtime connections.
+var serviceBusNamespaceNameForKeda = replace(serviceBusNamespace, '.servicebus.windows.net', '')
+
 // Logging options
 // We intentionally do NOT enable Log Analytics (cost).
 // To route logs to a Storage Account via Azure Monitor diagnostic settings, the environment must have
@@ -1050,7 +1054,7 @@ resource parsingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'parsing'
                 messageCount: '5'
                 activationMessageCount: '1'
-                namespace: serviceBusNamespace
+                namespace: serviceBusNamespaceNameForKeda
               }
               // Authentication: KEDA uses the parsing service's user-assigned managed identity
               // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep
@@ -1229,7 +1233,7 @@ resource chunkingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'chunking'
                 messageCount: '5'
                 activationMessageCount: '1'
-                namespace: serviceBusNamespace
+                namespace: serviceBusNamespaceNameForKeda
               }
               // Authentication: KEDA uses the chunking service's user-assigned managed identity
               // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep
@@ -1465,7 +1469,7 @@ resource embeddingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'embedding'
                 messageCount: '5'
                 activationMessageCount: '1'
-                namespace: serviceBusNamespace
+                namespace: serviceBusNamespaceNameForKeda
               }
               // Authentication: KEDA uses the embedding service's user-assigned managed identity
               // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep
@@ -1701,7 +1705,7 @@ resource orchestratorApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'orchestrator'
                 messageCount: '5'
                 activationMessageCount: '1'
-                namespace: serviceBusNamespace
+                namespace: serviceBusNamespaceNameForKeda
               }
               // Authentication: KEDA uses the orchestrator service's user-assigned managed identity
               // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep
@@ -1944,7 +1948,7 @@ resource summarizationApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'summarization'
                 messageCount: '5'
                 activationMessageCount: '1'
-                namespace: serviceBusNamespace
+                namespace: serviceBusNamespaceNameForKeda
               }
               // Authentication: KEDA uses the summarization service's user-assigned managed identity
               // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep


### PR DESCRIPTION
RCA: Azure Portal shows Service Bus KEDA scale rules without a managed identity because the deployed scale rules currently omit custom.identity (see z containerapp show ... --query properties.template.scale.rules).

Root cause: our original attempt to set managed identity for the zure-servicebus scaler used the 2024-03-01 Container Apps API version, and the RP rejected the request with ContainerAppInvalidSchema at $[0].custom. To unblock deployment we temporarily removed the identity field, which makes the Portal appear as if MI isn't configured for the scaler.

Fix: bump Container Apps + Managed Environment API versions to 2025-01-01 and set scale.rules[].custom.identity to the service's user-assigned managed identity resource ID for parsing/chunking/embedding/orchestrator/summarization.

Validated via z deployment group validate (dev, westus) with parameters.local.json.