### PR TITLE
ACA: wake Service Bus consumers on single message

### DIFF
--- a/infra/azure/SCALE_TO_ZERO_CONFIGURATION.md
+++ b/infra/azure/SCALE_TO_ZERO_CONFIGURATION.md
@@ -34,11 +34,11 @@ The following services scale based on Azure Service Bus message queue depth usin
 
 | Service | Topic | Subscription | Messages per Replica | Activation Threshold |
 |---------|-------|--------------|---------------------|---------------------|
-| **parsing** | copilot.events | parsing | 5 | 1 |
-| **chunking** | copilot.events | chunking | 5 | 1 |
-| **embedding** | copilot.events | embedding | 5 | 1 |
-| **orchestrator** | copilot.events | orchestrator | 5 | 1 |
-| **summarization** | copilot.events | summarization | 5 | 1 |
+| **parsing** | copilot.events | parsing | 5 | 0 |
+| **chunking** | copilot.events | chunking | 5 | 0 |
+| **embedding** | copilot.events | embedding | 5 | 0 |
+| **orchestrator** | copilot.events | orchestrator | 5 | 0 |
+| **summarization** | copilot.events | summarization | 5 | 0 |
 
 ## Configuration Details
 
@@ -228,7 +228,7 @@ The Qdrant vector database service is currently configured **without persistent 
 
 **Service Bus Consumers**:
 - `messageCount`: Messages per replica (5 = process 5 messages per instance)
-- `activationMessageCount`: Must be set to '0' to wake from 0 when at least 1 message is present. Note: '1' does NOT mean ">= 1" and would change the activation threshold.
+- `activationMessageCount`: Set to `0` if you want scale-from-zero to activate on a single message. Use higher values to intentionally raise the activation threshold (KEDA compares queue length against this threshold, e.g., `10` means "activate when there are at least 10 messages").
 - `maxReplicas`: Cap based on Service Bus throughput limits
 
 **Example tuning scenarios**:

--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -1054,9 +1054,9 @@ resource parsingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'parsing'
                 messageCount: '5'
                 // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
-                // to wake from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
-                // and would change the activation threshold. This intentionally differs from older
-                // SCALE_TO_ZERO_CONFIGURATION.md text to avoid future misconfiguration/reverts.
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would change the activation threshold. See SCALE_TO_ZERO_CONFIGURATION.md for rationale
+                // and additional guidance on this configuration.
                 activationMessageCount: '0'
                 namespace: serviceBusNamespaceNameForKeda
               }
@@ -1237,9 +1237,9 @@ resource chunkingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'chunking'
                 messageCount: '5'
                 // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
-                // to wake from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
-                // and would change the activation threshold. This intentionally differs from older
-                // SCALE_TO_ZERO_CONFIGURATION.md text to avoid future misconfiguration/reverts.
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would instead change the activation threshold, breaking scale-from-zero behavior.
+                // See SCALE_TO_ZERO_CONFIGURATION.md for the full rationale and related guidance.
                 activationMessageCount: '0'
                 namespace: serviceBusNamespaceNameForKeda
               }
@@ -1477,9 +1477,9 @@ resource embeddingApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'embedding'
                 messageCount: '5'
                 // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
-                // to wake from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
-                // and would change the activation threshold. This intentionally differs from older
-                // SCALE_TO_ZERO_CONFIGURATION.md text to avoid future misconfiguration/reverts.
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would change the activation threshold. This setting matches the documented
+                // behavior in SCALE_TO_ZERO_CONFIGURATION.md and helps avoid misconfiguration/reverts.
                 activationMessageCount: '0'
                 namespace: serviceBusNamespaceNameForKeda
               }
@@ -1717,9 +1717,9 @@ resource orchestratorApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'orchestrator'
                 messageCount: '5'
                 // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
-                // to wake from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
-                // and would change the activation threshold. This intentionally differs from older
-                // SCALE_TO_ZERO_CONFIGURATION.md text to avoid future misconfiguration/reverts.
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would change the activation threshold. See SCALE_TO_ZERO_CONFIGURATION.md
+                // for the canonical scale-to-zero configuration details.
                 activationMessageCount: '0'
                 namespace: serviceBusNamespaceNameForKeda
               }
@@ -1964,9 +1964,9 @@ resource summarizationApp 'Microsoft.App/containerApps@2025-01-01' = {
                 subscriptionName: 'summarization'
                 messageCount: '5'
                 // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
-                // to wake from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
-                // and would change the activation threshold. This intentionally differs from older
-                // SCALE_TO_ZERO_CONFIGURATION.md text to avoid future misconfiguration/reverts.
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would change the activation threshold. See SCALE_TO_ZERO_CONFIGURATION.md for
+                // the authoritative description of this setting; this configuration matches that doc.
                 activationMessageCount: '0'
                 namespace: serviceBusNamespaceNameForKeda
               }


### PR DESCRIPTION
Sets KEDA azure-servicebus scaler activationMessageCount to 0 for consumer services so a backlog of 1 message triggers scale-from-zero. Keeps minReplicas at 0, so services still scale back to zero after cooldown when backlog returns to 0.