### PR TITLE
build(deps): Bump cryptography from 46.0.3 to 46.0.4 (unified)

### DIFF
--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==3.4.4
     # via requests
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/chunking/requirements.txt
+++ b/chunking/requirements.txt
@@ -14,7 +14,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -14,7 +14,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -21,7 +21,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -20,7 +20,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/parsing/requirements.txt
+++ b/parsing/requirements.txt
@@ -16,7 +16,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -23,7 +23,7 @@ charset-normalizer==3.4.4
     # via requests
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in

--- a/summarization/requirements.txt
+++ b/summarization/requirements.txt
@@ -14,7 +14,7 @@ cffi==2.0.0
     # via cryptography
 click==8.3.1
     # via uvicorn
-cryptography==46.0.3
+cryptography==46.0.4
     # via -r requirements.in
 fastapi==0.128.0
     # via -r requirements.in


### PR DESCRIPTION
## Summary
Bumps [cryptography](https://github.com/pyca/cryptography) from 46.0.3 to 46.0.4 across all services.

This unified PR consolidates the following dependabot PRs:
- #1053 (chunking)
- #1054 (summarization)
- #1055 (parsing)
- #1056 (embedding)
- #1057 (orchestrator)
- #1058 (reporting)
- #1059 (ingestion)
- #1060 (auth)

### Services Updated
- \uth/requirements.txt\
- \chunking/requirements.txt\
- \mbedding/requirements.txt\
- \ingestion/requirements.txt\
- \orchestrator/requirements.txt\
- \parsing/requirements.txt\
- \eporting/requirements.txt\
- \summarization/requirements.txt\

### Validation
- [x] Ran \python scripts/update-dependabot.py\ locally - configuration is up to date
- [x] All 8 services updated consistently

### Next Steps
After merging this PR, the individual dependabot PRs (#1053-#1060) should be closed.