### PR TITLE
fix: add KEDA Service Bus scaling rule to reporting service

### DIFF
--- a/infra/azure/modules/containerapps.bicep
+++ b/infra/azure/modules/containerapps.bicep
@@ -719,6 +719,26 @@ resource reportingApp 'Microsoft.App/containerApps@2025-01-01' = {
               }
             }
           }
+          {
+            name: 'servicebus-scaling'
+            custom: {
+              type: 'azure-servicebus'
+              identity: identityResourceIds.reporting
+              metadata: {
+                topicName: 'copilot.events'
+                subscriptionName: 'reporting'
+                messageCount: '5'
+                // NOTE: For the Azure Service Bus KEDA scaler, activationMessageCount **must** be '0'
+                // to allow scaling from 0 when there is at least 1 message. A value of '1' does not mean ">= 1"
+                // and would change the activation threshold. See SCALE_TO_ZERO_CONFIGURATION.md for
+                // the authoritative description of this setting.
+                activationMessageCount: '0'
+                namespace: serviceBusNamespaceNameForKeda
+              }
+              // Authentication: KEDA uses the reporting service's user-assigned managed identity
+              // The identity has Azure Service Bus Data Receiver role assigned via servicebus.bicep
+            }
+          }
         ]
       }
     }


### PR DESCRIPTION
## Summary

Adds missing KEDA Service Bus scaling rule to the reporting service Container App, allowing it to scale up when messages arrive on its subscription.

## Problem

The reporting service only had HTTP-based scaling configured. When the service scaled to 0 due to no HTTP traffic, messages arriving on the `reporting` subscription in Service Bus had no trigger to scale the service back up. This caused messages to accumulate indefinitely without being processed.

All other message-consuming services (parsing, chunking, embedding, orchestrator, summarization) already had Service Bus scaling rules configured.

## Solution

Add an `azure-servicebus` KEDA scaling rule to the reporting Container App:
- Monitors the `copilot.events` topic's `reporting` subscription
- Scales up when messages arrive (`activationMessageCount: '0'`)
- Uses the reporting service's managed identity for authentication

## Changes

- `infra/azure/modules/containerapps.bicep`: Add Service Bus scaling rule to reporting app

## Testing

- Configuration matches pattern used by other services
- Requires infrastructure redeployment to take effect

Fixes #1128