### PR TITLE
fix: pin transformers<5.0.0 to avoid breaking changes

### DIFF
--- a/adapters/copilot_embedding/setup.py
+++ b/adapters/copilot_embedding/setup.py
@@ -51,14 +51,14 @@ setup(
             "openai>=1.0.0",
         ],
         "huggingface": [
-            "transformers>=4.0.0",
+            "transformers>=4.0.0,<5.0.0",
             "torch>=2.0.0",
         ],
         # All optional backends
         "all": [
             "sentence-transformers>=2.0.0",
             "openai>=1.0.0",
-            "transformers>=4.0.0",
+            "transformers>=4.0.0,<5.0.0",
             "torch>=2.0.0",
         ],
         # Test extra includes all drivers for factory tests
@@ -67,7 +67,7 @@ setup(
             "pytest-cov>=4.0.0",
             "sentence-transformers>=2.0.0",
             "openai>=1.0.0",
-            "transformers>=4.0.0",
+            "transformers>=4.0.0,<5.0.0",
             "torch>=2.0.0",
         ],
     },


### PR DESCRIPTION
## Summary

Pin `transformers` to v4.x to fix CI failures caused by breaking changes in v5.0.0.

## Problem

The Docker Compose CI workflow started failing with:

```
embedding-1 | Failed to start embedding service: name 'nn' is not defined
```

This is caused by **transformers v5.0.0** (released January 26, 2026), which has breaking changes that cause import errors when used with `sentence-transformers`.

## Root Cause

The `copilot_embedding` adapter had unpinned version specifiers (`transformers>=4.0.0`), allowing pip to install the latest v5.0.0 release which contains a bug where `torch.nn` is not properly imported in some modules.

## Solution

Pin `transformers>=4.0.0,<5.0.0` in all extras_require sections to stay on the stable v4.x series until the upstream issue is resolved.

## Changes

- `adapters/copilot_embedding/setup.py`: Pin transformers to <5.0.0 in huggingface, all, and test extras

## Related

- Upstream issue: https://github.com/huggingface/transformers/issues/43784