### PR TITLE
build(deps): Consolidate dependabot dependency updates

### DIFF
--- a/.github/workflows/azure-integration-ci.yml
+++ b/.github/workflows/azure-integration-ci.yml
@@ -112,7 +112,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Azure Dockerfile (no push)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}

--- a/.github/workflows/publish-docker-images-azure.yml
+++ b/.github/workflows/publish-docker-images-azure.yml
@@ -109,7 +109,7 @@ jobs:
             type=raw,value=azure-{{sha}},enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -107,7 +107,7 @@ jobs:
             type=sha,prefix=,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ${{ matrix.service.context }}
           file: ${{ matrix.service.dockerfile }}

--- a/.github/workflows/service-reusable-unit-test-ci.yml
+++ b/.github/workflows/service-reusable-unit-test-ci.yml
@@ -161,7 +161,7 @@ jobs:
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Build Docker image
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ./
         file: ./${{ inputs.service_path }}/Dockerfile

--- a/adapters/copilot_metrics/setup.py
+++ b/adapters/copilot_metrics/setup.py
@@ -46,15 +46,15 @@ setup(
             # Pin to the current beta until a stable 1.x release is available
             # azure-monitor-opentelemetry-exporter==1.0.0b48 requires opentelemetry==1.39
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39.1",
-            "opentelemetry-sdk==1.39.1",
+            "opentelemetry-api==1.39",
+            "opentelemetry-sdk==1.39",
         ],
         # All optional backends
         "all": [
             "prometheus-client>=0.19.0",
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39.1",
-            "opentelemetry-sdk==1.39.1",
+            "opentelemetry-api==1.39",
+            "opentelemetry-sdk==1.39",
         ],
         # Test extra includes all drivers for factory tests
         "test": [
@@ -62,8 +62,8 @@ setup(
             "pytest-cov>=4.0.0",
             "prometheus-client>=0.19.0",
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39.1",
-            "opentelemetry-sdk==1.39.1",
+            "opentelemetry-api==1.39",
+            "opentelemetry-sdk==1.39",
         ],
     },
 )

--- a/adapters/copilot_metrics/setup.py
+++ b/adapters/copilot_metrics/setup.py
@@ -46,15 +46,15 @@ setup(
             # Pin to the current beta until a stable 1.x release is available
             # azure-monitor-opentelemetry-exporter==1.0.0b48 requires opentelemetry==1.39
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39",
-            "opentelemetry-sdk==1.39",
+            "opentelemetry-api==1.39.1",
+            "opentelemetry-sdk==1.39.1",
         ],
         # All optional backends
         "all": [
             "prometheus-client>=0.19.0",
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39",
-            "opentelemetry-sdk==1.39",
+            "opentelemetry-api==1.39.1",
+            "opentelemetry-sdk==1.39.1",
         ],
         # Test extra includes all drivers for factory tests
         "test": [
@@ -62,8 +62,8 @@ setup(
             "pytest-cov>=4.0.0",
             "prometheus-client>=0.19.0",
             "azure-monitor-opentelemetry-exporter==1.0.0b48",
-            "opentelemetry-api==1.39",
-            "opentelemetry-sdk==1.39",
+            "opentelemetry-api==1.39.1",
+            "opentelemetry-sdk==1.39.1",
         ],
     },
 )

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -26,7 +26,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -54,7 +54,7 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
-pydantic-settings==2.12.0
+pydantic-settings==2.13.0
     # via -r requirements.in
 pyjwt==2.11.0
     # via -r requirements.in
@@ -85,7 +85,7 @@ typing-inspection==0.4.2
     #   pydantic-settings
 urllib3==2.6.3
     # via requests
-uvicorn==0.40.0 ; platform_system != "Windows"
+uvicorn==0.41.0 ; platform_system != "Windows"
     # via -r requirements.in
 uvloop==0.22.1
     # via uvicorn

--- a/auth/requirements.txt
+++ b/auth/requirements.txt
@@ -26,7 +26,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -54,7 +54,7 @@ pydantic==2.12.5
     #   pydantic-settings
 pydantic-core==2.41.5
     # via pydantic
-pydantic-settings==2.13.0
+pydantic-settings==2.13.1
     # via -r requirements.in
 pyjwt==2.11.0
     # via -r requirements.in

--- a/chunking/requirements.txt
+++ b/chunking/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -62,5 +62,5 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/chunking/requirements.txt
+++ b/chunking/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -62,5 +62,5 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/embedding/requirements.txt
+++ b/embedding/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -23,7 +23,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -71,7 +71,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0 ; platform_system != "Windows"
+uvicorn==0.41.0 ; platform_system != "Windows"
     # via -r requirements.in
 uvloop==0.22.1
     # via uvicorn

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -23,7 +23,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -62,5 +62,5 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/parsing/requirements.txt
+++ b/parsing/requirements.txt
@@ -24,7 +24,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -65,5 +65,5 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/parsing/requirements.txt
+++ b/parsing/requirements.txt
@@ -24,7 +24,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -25,7 +25,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -70,5 +70,5 @@ typing-inspection==0.4.2
     #   pydantic
 urllib3==2.6.3
     # via requests
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/reporting/requirements.txt
+++ b/reporting/requirements.txt
@@ -25,7 +25,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/summarization/requirements.txt
+++ b/summarization/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.128.8
+fastapi==0.129.0
     # via -r requirements.in
 h11==0.16.0
     # via
@@ -62,5 +62,5 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.40.0
+uvicorn==0.41.0
     # via -r requirements.in

--- a/summarization/requirements.txt
+++ b/summarization/requirements.txt
@@ -22,7 +22,7 @@ click==8.3.1
     # via uvicorn
 cryptography==46.0.5
     # via -r requirements.in
-fastapi==0.129.0
+fastapi==0.133.0
     # via -r requirements.in
 h11==0.16.0
     # via

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,8 +23,8 @@
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/coverage-v8": "^4.0.18",
         "@vitest/ui": "^4.0.17",
-        "happy-dom": "^20.6.1",
-        "jsdom": "^28.0.0",
+        "happy-dom": "^20.6.2",
+        "jsdom": "^28.1.0",
         "typescript": "^5.6.2",
         "vite": "^7.3.1",
         "vitest": "^4.0.17"
@@ -45,23 +45,23 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
-      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.4",
-        "@csstools/css-color-parser": "^3.1.0",
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4",
-        "lru-cache": "^11.2.4"
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.7.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
-      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -79,13 +79,13 @@
         "bidi-js": "^1.0.3",
         "css-tree": "^3.1.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.4"
+        "lru-cache": "^11.2.6"
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -130,7 +130,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -402,10 +401,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
       "dev": true,
       "funding": [
         {
@@ -419,13 +431,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
       "dev": true,
       "funding": [
         {
@@ -439,17 +451,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
       "dev": true,
       "funding": [
         {
@@ -463,21 +475,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
       "dev": true,
       "funding": [
         {
@@ -490,18 +502,17 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
-      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
       "dev": true,
       "funding": [
         {
@@ -513,15 +524,12 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "dev": true,
       "funding": [
         {
@@ -534,9 +542,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1473,7 +1480,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1601,7 +1609,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1612,7 +1619,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1801,7 +1807,6 @@
       "integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.18",
         "fflate": "^0.8.2",
@@ -1848,6 +1853,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1858,6 +1864,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1954,7 +1961,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2102,25 +2108,25 @@
       "license": "MIT"
     },
     "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
         "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
+        "lru-cache": "^11.2.5"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2221,7 +2227,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -2396,22 +2403,34 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.6.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.6.1.tgz",
-      "integrity": "sha512-+0vhESXXhFwkdjZnJ5DlmJIfUYGgIEEjzIjB+aKJbFuqlvvKyOi+XkI1fYbgYR9QCxG5T08koxsQ6HrQfa5gCQ==",
+      "version": "20.6.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.6.2.tgz",
+      "integrity": "sha512-Xk/Y0cuq9ngN/my8uvK4gKoyDl6sBKkIl8A/hJ0IabZVH7E5SJLHNE7uKRPVmSrQbhJaLIHTEcvTct4GgNtsRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
         "@types/ws": "^8.18.1",
-        "entities": "^6.0.1",
+        "entities": "^7.0.1",
         "whatwg-mimetype": "^3.0.0",
         "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/has-flag": {
@@ -2648,16 +2667,17 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
-      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
         "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^5.3.7",
+        "cssstyle": "^6.0.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
@@ -2668,7 +2688,7 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.0",
-        "undici": "^7.20.0",
+        "undici": "^7.21.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -2758,6 +2778,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3536,7 +3557,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3579,6 +3599,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3613,7 +3634,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3623,7 +3643,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3636,7 +3655,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -4103,9 +4123,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-      "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4271,7 +4291,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4347,7 +4366,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,8 +28,8 @@
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "@vitest/ui": "^4.0.17",
-    "happy-dom": "^20.6.1",
-    "jsdom": "^28.0.0",
+    "happy-dom": "^20.6.2",
+    "jsdom": "^28.1.0",
     "typescript": "^5.6.2",
     "vite": "^7.3.1",
     "vitest": "^4.0.17"


### PR DESCRIPTION
## Combined Dependabot Updates

This PR consolidates 11 individual dependabot PRs into a single update:

### GitHub Actions
- `docker/build-push-action` 6.18.0  6.19.2 (#1183)

### Python Dependencies
- `fastapi` 0.128.8  0.129.0 (auth, ingestion, reporting, summarization, chunking, embedding, parsing, orchestrator)
- `uvicorn` 0.40.0  0.41.0 (auth, ingestion, reporting, summarization, chunking, embedding, parsing, orchestrator)
- `pydantic-settings` 2.12.0  2.13.0 (auth) (#1182)
- `opentelemetry-api` 1.39  1.39.1 (copilot_metrics) (#1173)
- `opentelemetry-sdk` 1.39  1.39.1 (copilot_metrics) (#1173)

### Node.js Dependencies
- `happy-dom` 20.6.1  20.6.2 (ui) (#1181)
- `jsdom` 28.0.0  28.1.0 (ui) (#1181)

### Supersedes
Closes #1183, closes #1182, closes #1181, closes #1180, closes #1179, closes #1178, closes #1177, closes #1176, closes #1175, closes #1174, closes #1173